### PR TITLE
Drop g.Game#logger

### DIFF
--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -1,5 +1,5 @@
 import { akashicEngine as g, gameDriver as gdr } from "@akashic/engine-files";
-import { Runner, RunnerLogLevel } from "@akashic/headless-driver-runner";
+import { Runner } from "@akashic/headless-driver-runner";
 import { PlatformV1 } from "./platform/PlatformV1";
 
 export type RunnerV1Game = g.Game;
@@ -59,6 +59,7 @@ export class RunnerV1 extends Runner {
 				configurationBaseUrl: this.configurationBaseUrl,
 				assetBaseUrl: this.assetBaseUrl,
 				amflow: this.amflow,
+				sendToExternalHandler: (data: any) => this.onSendedToExternal(data),
 				errorHandler: (e: any) => this.onError(e)
 			});
 
@@ -96,8 +97,6 @@ export class RunnerV1 extends Runner {
 			);
 
 			driver.gameCreatedTrigger.handle((game: RunnerV1Game) => {
-				game.logger.logging.remove(this, this.convertLog);
-				game.logger.logging.handle(this, this.convertLog);
 				game._started.handle(() => {
 					resolve(game);
 					return true;
@@ -108,22 +107,7 @@ export class RunnerV1 extends Runner {
 		});
 	}
 
-	private convertLog(log: g.Log): void {
-		let level: RunnerLogLevel;
-		if (log.level === g.LogLevel.Debug) {
-			level = "debug";
-		} else if (log.level === g.LogLevel.Warn) {
-			level = "warn";
-		} else if (log.level === g.LogLevel.Error) {
-			level = "error";
-		} else {
-			level = "info";
-		}
-
-		this.onLogging({
-			level,
-			message: log.message,
-			cause: log.cause
-		});
+	private onSendedToExternal(data: any): void {
+		this.sendToExternalTrigger.fire(data);
 	}
 }

--- a/packages/headless-driver-runner-v1/src/platform/PlatformV1.ts
+++ b/packages/headless-driver-runner-v1/src/platform/PlatformV1.ts
@@ -26,7 +26,7 @@ export class PlatformV1 extends Platform implements pdi.Platform {
 	}
 
 	setPlatformEventHandler(handler: pdi.PlatformEventHandler): void {
-		// TODO
+		// do noting
 	}
 
 	getPrimarySurface(): g.Surface {

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -1,5 +1,5 @@
 import { akashicEngine as g, gameDriver as gdr } from "@akashic/engine-files";
-import { Runner, RunnerLogLevel } from "@akashic/headless-driver-runner";
+import { Runner } from "@akashic/headless-driver-runner";
 import { PlatformV2 } from "./platform/PlatformV2";
 
 export type RunnerV2Game = g.Game;
@@ -59,6 +59,7 @@ export class RunnerV2 extends Runner {
 				configurationBaseUrl: this.configurationBaseUrl,
 				assetBaseUrl: this.assetBaseUrl,
 				amflow: this.amflow,
+				sendToExternalHandler: (data: any) => this.onSendedToExternal(data),
 				errorHandler: (e: any) => this.onError(e)
 			});
 
@@ -96,29 +97,12 @@ export class RunnerV2 extends Runner {
 			);
 
 			driver.gameCreatedTrigger.addOnce((game: RunnerV2Game) => {
-				game.logger.logging.remove(this.convertLog, this);
-				game.logger.logging.add(this.convertLog, this);
 				game._started.addOnce(() => resolve(game));
 			});
 		});
 	}
 
-	private convertLog(log: g.Log): void {
-		let level: RunnerLogLevel;
-		if (log.level === g.LogLevel.Debug) {
-			level = "debug";
-		} else if (log.level === g.LogLevel.Warn) {
-			level = "warn";
-		} else if (log.level === g.LogLevel.Error) {
-			level = "error";
-		} else {
-			level = "info";
-		}
-
-		this.onLogging({
-			level,
-			message: log.message,
-			cause: log.cause
-		});
+	private onSendedToExternal(data: any): void {
+		this.sendToExternalTrigger.fire(data);
 	}
 }

--- a/packages/headless-driver-runner-v2/src/platform/PlatformV2.ts
+++ b/packages/headless-driver-runner-v2/src/platform/PlatformV2.ts
@@ -1,8 +1,8 @@
 import { akashicEngine as g, pdi } from "@akashic/engine-files";
+import { Looper, Platform, PlatformParameters } from "@akashic/headless-driver-runner";
 
 import { ResourceFactory } from "./ResourceFactory";
 import { NullSurface } from "./NullSurface";
-import { Looper, Platform, PlatformParameters } from "@akashic/headless-driver-runner";
 
 export class PlatformV2 extends Platform implements pdi.Platform {
 	private resFac: g.ResourceFactory;

--- a/packages/headless-driver-runner/src/Platform.ts
+++ b/packages/headless-driver-runner/src/Platform.ts
@@ -5,6 +5,7 @@ export interface PlatformParameters {
 	assetBaseUrl: string;
 	configurationBaseUrl?: string;
 	amflow: AMFlow;
+	sendToExternalHandler: (data: any) => void;
 	errorHandler: (err: any) => void;
 }
 
@@ -13,17 +14,19 @@ export abstract class Platform {
 	assetBaseUrl: string;
 	configurationBaseUrl: string;
 
+	protected sendToExternalHandler: (data: any) => void;
 	protected errorHandler: (err: any) => void;
 
 	constructor(param: PlatformParameters) {
 		this.assetBaseUrl = param.assetBaseUrl;
 		this.configurationBaseUrl = param.configurationBaseUrl;
 		this.amflow = param.amflow;
+		this.sendToExternalHandler = param.sendToExternalHandler;
 		this.errorHandler = param.errorHandler;
 	}
 
-	sendToExternal(data: any): void {
-		// TODO
+	sendToExternal(playId: string, data: any): void {
+		this.sendToExternalHandler(data);
 	}
 
 	loadGameConfiguration(url: string, callback: (err: Error, data?: object) => void): void {

--- a/packages/headless-driver-runner/src/Runner.ts
+++ b/packages/headless-driver-runner/src/Runner.ts
@@ -22,38 +22,10 @@ export interface RunnerPlayer {
 	name: string;
 }
 
-/**
- * ログレベル。
- *
- * - Error: サーバ側でも収集される、ゲーム続行不可能なクリティカルなエラーログ
- * - Warn: サーバ側でも収集される、ゲーム続行可能だが危険な状態であることを示す警告ログ
- * - Info: クライアントでのみ収集される情報ログ
- * - Debug: サンドボックス環境でのみ収集される開発時限定のログ。リリース時には本処理をすべて消してリリースすることが望ましい
- */
-export type RunnerLogLevel = "error" | "warn" | "info" | "debug";
-
-/**
- * ログ出力情報。
- */
-export interface RunnerLog {
-	/**
-	 * ログレベル。
-	 */
-	level: RunnerLogLevel;
-	/**
-	 * ログ内容。
-	 */
-	message: string;
-	/**
-	 * ゲーム開発者が任意に利用できる、汎用のログ補助情報。
-	 */
-	cause?: any;
-}
-
 export abstract class Runner {
 	engineVersion: string;
 	errorTrigger: Trigger<any> = new Trigger();
-	logTrigger: Trigger<RunnerLog> = new Trigger();
+	sendToExternalTrigger: Trigger<any> = new Trigger();
 
 	private params: RunnerParameters;
 
@@ -111,9 +83,5 @@ export abstract class Runner {
 	protected onError(error: Error): void {
 		this.stop();
 		this.errorTrigger.fire(error);
-	}
-
-	protected onLogging(log: RunnerLog): void {
-		this.logTrigger.fire(log);
 	}
 }

--- a/packages/headless-driver/src/__tests__/contents/content-v1/script/main.js
+++ b/packages/headless-driver/src/__tests__/contents/content-v1/script/main.js
@@ -17,7 +17,7 @@ function main(param) {
 			// 以下のコードは毎フレーム実行されます。
 			rect.x += 10;
 			if (rect.x > game.width) {
-				game.logger.info("reached right");
+				game.external.send("reached right");
 				rect.x = 0;
 			}
 			rect.modified();
@@ -34,7 +34,7 @@ function main(param) {
 			}));
 			return;
 		}
-		game.logger.info(message);
+		game.external.send(message);
 	});
 	game.pushScene(scene);
 }

--- a/packages/headless-driver/src/__tests__/contents/content-v2/script/main.js
+++ b/packages/headless-driver/src/__tests__/contents/content-v2/script/main.js
@@ -17,7 +17,7 @@ function main(param) {
 			// 以下のコードは毎フレーム実行されます。
 			rect.x += 10;
 			if (rect.x > game.width) {
-				game.logger.info("reached right");
+				game.external.send("reached right");
 				rect.x = 0;
 			}
 			rect.modified();
@@ -34,7 +34,7 @@ function main(param) {
 			}));
 			return;
 		}
-		game.logger.info(message);
+		game.external.send(message);
 	});
 	game.pushScene(scene);
 }

--- a/packages/headless-driver/src/__tests__/index.ts
+++ b/packages/headless-driver/src/__tests__/index.ts
@@ -450,22 +450,22 @@ describe("コンテンツ動作テスト", () => {
 		const game = (await runnerManager.startRunner(runner.runnerId)) as RunnerV1Game;
 		assert.equal(game.playId, playId);
 
-		const handleLog = () =>
+		const handleData = () =>
 			new Promise<any>((resolve, reject) => {
-				// コンテンツ側での g.Game#logger の出力を捕捉できる
-				runner.logTrigger.handle((l: any) => {
+				// コンテンツ側での g.Game#external.send() を捕捉できる
+				runner.sendToExternalTrigger.handle((l: any) => {
 					resolve(l);
 					return true;
 				});
 			});
 
-		const log = await handleLog();
-		assert.equal(log.message, "reached right");
+		const data = await handleData();
+		assert.equal(data, "reached right");
 
 		const handleError = () =>
 			new Promise<any>((resolve, reject) => {
-				// コンテンツ側での g.Game#logger の出力を捕捉できる
-				runner.logTrigger.handle((l: any) => {
+				// コンテンツ側での g.Game#external.send() を捕捉できる
+				runner.sendToExternalTrigger.handle((l: any) => {
 					resolve(l);
 					return true;
 				});
@@ -474,10 +474,10 @@ describe("コンテンツ動作テスト", () => {
 		// AMFlow 経由でイベントを送信でき、それをコンテンツで捕捉できる
 		activeAMFlow.sendEvent([0x20, null, ":akashic", { hoge: "fuga" }]);
 
-		// 読み込んだコンテンツ側で受信したメッセージイベントをログに出力しているので、ここで内容を取得する
+		// 読み込んだコンテンツ側で受信したメッセージイベントを出力しているので、ここで内容を取得する
 		const event = await handleError();
-		assert.deepEqual(event.message.data, { hoge: "fuga" });
-		assert.equal(event.message.player.id, ":akashic");
+		assert.deepEqual(event.data, { hoge: "fuga" });
+		assert.equal(event.player.id, ":akashic");
 
 		runner.stop();
 	});
@@ -507,21 +507,21 @@ describe("コンテンツ動作テスト", () => {
 		const game = (await runnerManager.startRunner(runner.runnerId)) as RunnerV2Game;
 		assert.equal(game.playId, playId);
 
-		const handleLog = () =>
+		const handleData = () =>
 			new Promise<any>((resolve, reject) => {
-				// コンテンツ側での g.Game#logger の出力を捕捉できる
-				runner.logTrigger.addOnce(l => {
+				// コンテンツ側での g.Game#external.send() を捕捉できる
+				runner.sendToExternalTrigger.addOnce(l => {
 					resolve(l);
 				});
 			});
 
-		const log = await handleLog();
-		assert.equal(log.message, "reached right");
+		const data = await handleData();
+		assert.equal(data, "reached right");
 
 		const handleEvent = () =>
 			new Promise<any>((resolve, reject) => {
-				// コンテンツ側での g.Game#logger の出力を捕捉できる
-				runner.logTrigger.addOnce(l => {
+				// コンテンツ側での g.Game#external.send() を捕捉できる
+				runner.sendToExternalTrigger.addOnce(l => {
 					resolve(l);
 				});
 			});
@@ -529,10 +529,10 @@ describe("コンテンツ動作テスト", () => {
 		// AMFlow 経由でイベントを送信でき、それをコンテンツで捕捉できる
 		activeAMFlow.sendEvent([0x20, null, ":akashic", { hoge: "fuga" }]);
 
-		// 読み込んだコンテンツで受信したメッセージイベントをログに出力しているので、ここで内容を取得する
+		// 読み込んだコンテンツで受信したメッセージイベントを出力しているので、ここで内容を取得する
 		const event = await handleEvent();
-		assert.deepEqual(event.message.data, { hoge: "fuga" });
-		assert.equal(event.message.player.id, ":akashic");
+		assert.deepEqual(event.data, { hoge: "fuga" });
+		assert.equal(event.player.id, ":akashic");
 		runner.stop();
 	});
 
@@ -572,18 +572,18 @@ describe("コンテンツ動作テスト", () => {
 		passiveAMFlow.sendEvent([0x20, null, ":akashic", "send_event"]);
 
 		// (2) (1) 送信後に Active 側のメッセージ受信ハンドラを登録
-		// NOTE: "data_from_content" 以外のメッセージイベントの捕捉を防ぐため、このタイミングでログをハンドルする
-		const handleLog = () =>
+		// NOTE: "data_from_content" 以外のメッセージイベントの捕捉を防ぐため、このタイミングで出力をハンドルする
+		const handleData = () =>
 			new Promise<any>((resolve, reject) => {
-				// NOTE: 読み込んだコンテンツ側で受信したメッセージイベントをログ出力しているので、ここで内容を取得する
-				activeRunner.logTrigger.addOnce(l => {
+				// NOTE: 読み込んだコンテンツ側で受信したメッセージイベントを出力しているので、ここで内容を取得する
+				activeRunner.sendToExternalTrigger.addOnce(l => {
 					resolve(l);
 				});
 			});
 
 		// (3) 受け取ったメッセージイベントの内容を確認
-		const event = await handleLog();
-		assert.equal(event.message.data.text, "data_from_content");
+		const event = await handleData();
+		assert.equal(event.data.text, "data_from_content");
 
 		activeRunner.stop();
 		passiveRunner.stop();
@@ -607,18 +607,18 @@ describe("コンテンツ動作テスト", () => {
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV2;
 
-		const handleLog = () =>
+		const handleData = () =>
 			new Promise<any>((resolve, reject) => {
-				// コンテンツ側での g.Game#logger の出力を捕捉できる
-				runner.logTrigger.addOnce(l => {
+				// コンテンツ側での g.Game#external.send() を捕捉できる
+				runner.sendToExternalTrigger.addOnce(l => {
 					resolve(l);
 				});
 			});
 
 		await runner.start();
 
-		const log = await handleLog();
-		assert.equal(log.message, "reached right");
+		const data = await handleData();
+		assert.equal(data, "reached right");
 		runner.stop();
 	});
 });


### PR DESCRIPTION
## このPullRequestが解決する内容
- `g.Game#logger` を捕捉している箇所を削除します。
   - ( cf: https://github.com/akashic-games/akashic-engine/pull/110 )
- テストでの代替処理として `g.Game#external.send()` を利用します。
- `Runner#sendToExternalTrigger: g.Trigger<any>` が新設されます。
- `Runner#logTrigger` が削除されます。

## 破壊的変更
**あり** 
マイナーバージョンの更新になります。