### PR TITLE
Resolve circular dependency

### DIFF
--- a/packages/headless-driver/src/__tests__/PlaySpec.ts
+++ b/packages/headless-driver/src/__tests__/PlaySpec.ts
@@ -90,7 +90,6 @@ describe("プレー周りのテスト", () => {
 		const token1 = amflowClientManager.createPlayToken("0", activePermission);
 		const authenticated1 = amflowClientManager.authenticatePlayToken("0", token1);
 		expect(authenticated1).toEqual(activePermission);
-		expect((amflowClientManager as any).playTokenMap["0"]).not.toBe(null);
 
 		amflowClientManager.createAMFlow("0");
 		const storeMap: Map<string, AMFlowStore> = (amflowClientManager as any).storeMap;
@@ -105,7 +104,6 @@ describe("プレー周りのテスト", () => {
 
 		amflowClientManager.deleteAllPlayTokens("0");
 		amflowClientManager.deleteAMFlowStore("0");
-		expect((amflowClientManager as any).playTokenMap["0"]).toBeUndefined();
 		expect(storeMap.get("0")).toBeUndefined();
 	});
 

--- a/packages/headless-driver/src/play/AMFlowClientManager.ts
+++ b/packages/headless-driver/src/play/AMFlowClientManager.ts
@@ -41,9 +41,9 @@ export class AMFlowClientManager {
 	 * @param token PlayToken
 	 */
 	deletePlayToken(playId: string, token: string): void {
-		let store = this.storeMap.get(playId);
+		const store = this.storeMap.get(playId);
 		if (!store) {
-			store = this.createAMFlowStore(playId);
+			return;
 		}
 		return store.deletePlayToken(token);
 	}
@@ -55,9 +55,9 @@ export class AMFlowClientManager {
 	 * @param revoke 対象の PlayToken を revoke するかどうか
 	 */
 	authenticatePlayToken(playId: string, token: string, revoke?: boolean): Permission | null {
-		let store = this.storeMap.get(playId);
+		const store = this.storeMap.get(playId);
 		if (!store) {
-			store = this.createAMFlowStore(playId);
+			return;
 		}
 		return store.authenticate(token, revoke);
 	}
@@ -67,9 +67,9 @@ export class AMFlowClientManager {
 	 * @param playId PlayID
 	 */
 	deleteAllPlayTokens(playId: string): void {
-		let store = this.storeMap.get(playId);
+		const store = this.storeMap.get(playId);
 		if (!store) {
-			store = this.createAMFlowStore(playId);
+			return;
 		}
 		return store.deleteAllPlayTokens();
 	}
@@ -93,9 +93,10 @@ export class AMFlowClientManager {
 	 */
 	suspendAMFlowStore(playId: string): void {
 		const store = this.storeMap.get(playId);
-		if (store) {
-			store.suspend();
+		if (!store) {
+			return;
 		}
+		store.suspend();
 	}
 
 	/**
@@ -104,9 +105,10 @@ export class AMFlowClientManager {
 	 */
 	resumeAMFlowStore(playId: string): void {
 		const store = this.storeMap.get(playId);
-		if (store) {
-			store.resume();
+		if (!store) {
+			return;
 		}
+		store.resume();
 	}
 
 	private createAMFlowStore(playId: string): AMFlowStore {

--- a/packages/headless-driver/src/play/AMFlowClientManager.ts
+++ b/packages/headless-driver/src/play/AMFlowClientManager.ts
@@ -57,7 +57,7 @@ export class AMFlowClientManager {
 	authenticatePlayToken(playId: string, token: string, revoke?: boolean): Permission | null {
 		const store = this.storeMap.get(playId);
 		if (!store) {
-			return;
+			return null;
 		}
 		return store.authenticate(token, revoke);
 	}


### PR DESCRIPTION
## このPullRequestが解決する内容
PlayToken と permission を紐付けるマップ情報を AMFlowStore にもたせます。
それにより `AMFlowClientManager.ts > AMFlowClient > AMFlowStore` 間の循環参照を解決します。