### PR TITLE
add plaaylog I/F to createPlay

### DIFF
--- a/packages/headless-driver/src/play/PlayManager.ts
+++ b/packages/headless-driver/src/play/PlayManager.ts
@@ -19,7 +19,7 @@ export class PlayManager {
 	private nextPlayId: number = 0;
 	private plays: Play[] = [];
 
- 	/**
+	/**
 	 * Play を作成する。
 	 * @param params パラメータ
 	 */
@@ -44,9 +44,10 @@ export class PlayManager {
 			};
 			const token = this.createPlayToken(playId, activePermission);
 
-			await new Promise((resolve, reject) => amflow.open(playId, (e: Error) => e ? reject(e) : resolve()));
-			await new Promise((resolve, reject) => amflow.authenticate(token, (e: Error) => e ? reject(e) : resolve()));
-			await new Promise((resolve, reject) => amflow.putStartPoint(playlog.startPoints[0], (e: Error) => e ? reject(e) : resolve()));
+			// TODO: プレイ生成時に AMFlowStore 生成し playlog を渡して初期化できるようにし、 AMFlowClient 経由で playlog を渡さず済むようにする
+			await new Promise((resolve, reject) => amflow.open(playId, (e: Error) => (e ? reject(e) : resolve())));
+			await new Promise((resolve, reject) => amflow.authenticate(token, (e: Error) => (e ? reject(e) : resolve())));
+			await new Promise((resolve, reject) => amflow.putStartPoint(playlog.startPoints[0], (e: Error) => (e ? reject(e) : resolve())));
 			amflow.setTickList(playlog.tickList);
 		}
 		return playId;

--- a/packages/headless-driver/src/play/PlayManager.ts
+++ b/packages/headless-driver/src/play/PlayManager.ts
@@ -21,16 +21,16 @@ export class PlayManager {
 
 	/**
 	 * Play を作成する。
-	 * @param params パラメータ
+	 * @param playLocation パラメータ
 	 */
-	async createPlay(params: PlayManagerParameters, playlog?: DumpedPlaylog): Promise<string> {
+	async createPlay(playLocation: PlayManagerParameters, playlog?: DumpedPlaylog): Promise<string> {
 		const playId = `${this.nextPlayId++}`;
 		this.plays.push({
 			playId,
 			status: "running",
 			createdAt: Date.now(),
 			lastSuspendedAt: null,
-			...params
+			...playLocation
 		});
 		if (playlog) {
 			const amflow = this.createAMFlow(playId);

--- a/packages/headless-driver/src/play/PlayManager.ts
+++ b/packages/headless-driver/src/play/PlayManager.ts
@@ -11,11 +11,6 @@ export interface PlayFilter {
 	status: PlayStatus;
 }
 
-interface PlaylogIndex {
-	playId: string;
-	playlog: DumpedPlaylog;
-}
-
 /**
  * Play を管理するマネージャ。
  */
@@ -23,7 +18,6 @@ export class PlayManager {
 	private amflowClientManager: AMFlowClientManager = new AMFlowClientManager();
 	private nextPlayId: number = 0;
 	private plays: Play[] = [];
-	private playlogIndex: PlaylogIndex[] = [];
 
  	/**
 	 * Play を作成する。
@@ -39,10 +33,6 @@ export class PlayManager {
 			...params
 		});
 		if (playlog) {
-			this.playlogIndex.push({
-				playId,
-				playlog
-			});
 			const amflow = this.createAMFlow(playId);
 			const activePermission = {
 				readTick: true,

--- a/packages/headless-driver/src/play/PlayManager.ts
+++ b/packages/headless-driver/src/play/PlayManager.ts
@@ -1,9 +1,9 @@
 import { Permission } from "@akashic/amflow";
 import { AMFlowClient } from "./amflow/AMFlowClient";
+import { DumpedPlaylog } from "./amflow/AMFlowStore";
 import { AMFlowClientManager } from "./AMFlowClientManager";
 import { ContentLocation } from "./Content";
 import { Play, PlayStatus } from "./Play";
-import { DumpedPlaylog } from "./amflow/AMFlowStore";
 
 export type PlayManagerParameters = ContentLocation;
 

--- a/packages/headless-driver/src/play/amflow/AMFlowClient.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowClient.ts
@@ -81,6 +81,10 @@ export class AMFlowClient implements AMFlow {
 		});
 	}
 
+    initTick(start: number, end: number) {
+        this.store.initTick(start, end);
+    }
+
 	sendTick(tick: Tick): void {
 		if (this.state !== "open") {
 			throw createError("invalid_status", "Client is not open");

--- a/packages/headless-driver/src/play/amflow/AMFlowClient.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowClient.ts
@@ -81,9 +81,9 @@ export class AMFlowClient implements AMFlow {
 		});
 	}
 
-    initTick(start: number, end: number) {
-        this.store.initTick(start, end);
-    }
+	initTick(start: number, end: number): void {
+		this.store.initTick(start, end);
+	}
 
 	sendTick(tick: Tick): void {
 		if (this.state !== "open") {

--- a/packages/headless-driver/src/play/amflow/AMFlowClient.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowClient.ts
@@ -81,8 +81,8 @@ export class AMFlowClient implements AMFlow {
 		});
 	}
 
-	initTick(start: number, end: number): void {
-		this.store.initTick(start, end);
+	setTickList(tickList: TickList): void {
+		this.store.setTickList(tickList);
 	}
 
 	sendTick(tick: Tick): void {

--- a/packages/headless-driver/src/play/amflow/AMFlowStore.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowStore.ts
@@ -37,6 +37,13 @@ export class AMFlowStore {
 		return permission;
 	}
 
+    initTick(start: number, end: number) {
+        if (this.tickList) {
+            throw createError("bad_request", "TickList alrady initialized");
+        }
+        this.tickList = [start, end, []];
+    }
+
 	sendTick(tick: Tick): void {
 		if (this.isSuspended()) {
 			throw createError("bad_request", "Play may be suspended");

--- a/packages/headless-driver/src/play/amflow/AMFlowStore.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowStore.ts
@@ -37,12 +37,12 @@ export class AMFlowStore {
 		return permission;
 	}
 
-    initTick(start: number, end: number) {
-        if (this.tickList) {
-            throw createError("bad_request", "TickList alrady initialized");
-        }
-        this.tickList = [start, end, []];
-    }
+	initTick(start: number, end: number): void {
+		if (this.tickList) {
+			throw createError("bad_request", "TickList alrady initialized");
+		}
+		this.tickList = [start, end, []];
+	}
 
 	sendTick(tick: Tick): void {
 		if (this.isSuspended()) {

--- a/packages/headless-driver/src/play/amflow/AMFlowStore.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowStore.ts
@@ -37,11 +37,8 @@ export class AMFlowStore {
 		return permission;
 	}
 
-	initTick(start: number, end: number): void {
-		if (this.tickList) {
-			throw createError("bad_request", "TickList alrady initialized");
-		}
-		this.tickList = [start, end, []];
+	setTickList(tickList: TickList): void {
+		this.tickList = tickList;
 	}
 
 	sendTick(tick: Tick): void {


### PR DESCRIPTION
### 概要
akashic serveの `--debug-playlog` に渡すplaylog.jsonの `TickList[2]` の最初のフレームよりも、 `TickList[0]` の開始フレームが若い番号の場合、clientに渡るTickListの開始フレームが `TickList[2]` になってしまう現象があります。
これを解決するため、headless-driverに開始フレームを受け取る口を作り、serveコマンドの実行時にこれを呼ぶことで開始フレームを正しく扱えるように修正します。
https://github.com/akashic-games/akashic-cli/blob/master/packages/akashic-cli-serve/src/server/domain/PlayStore.ts#L172