### PR TITLE
fix that runner-version will not be undefined

### DIFF
--- a/packages/headless-driver/src/runner/RunnerManager.ts
+++ b/packages/headless-driver/src/runner/RunnerManager.ts
@@ -124,7 +124,7 @@ export class RunnerManager {
 				}
 				version = defs.reduce((acc, def) => (def.environment && def.environment["sandbox-runtime"]) || acc, version);
 				configurationBaseUrl = url.resolve(engineConfiguration.content_url, "./");
-			} else if (gameConfiguration.environment) {
+			} else if (gameConfiguration.environment && gameConfiguration.environment["sandbox-runtime"]) {
 				version = gameConfiguration.environment["sandbox-runtime"];
 			}
 


### PR DESCRIPTION
### 概要
* コンテンツのgame.jsonに`environment`が定義されている且つ`environment["sandbox-runtime"]`が定義されていない場合runnerのversionがundefinedになってしまう不具合があったので修正する対応を行いました。