### PR TITLE
Add externalValue to Runner

### DIFF
--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -97,6 +97,11 @@ export class RunnerV1 extends Runner {
 			);
 
 			driver.gameCreatedTrigger.handle((game: RunnerV1Game) => {
+				if (this.externalValue) {
+					Object.keys(this.externalValue).forEach((key) => {
+						if (key) game.external[key] = this.externalValue[key];
+					});
+				}
 				game._started.handle(() => {
 					resolve(game);
 					return true;

--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -99,7 +99,7 @@ export class RunnerV1 extends Runner {
 			driver.gameCreatedTrigger.handle((game: RunnerV1Game) => {
 				if (this.externalValue) {
 					Object.keys(this.externalValue).forEach((key) => {
-						if (key) game.external[key] = this.externalValue[key];
+						game.external[key] = this.externalValue[key];
 					});
 				}
 				game._started.handle(() => {

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -97,6 +97,11 @@ export class RunnerV2 extends Runner {
 			);
 
 			driver.gameCreatedTrigger.addOnce((game: RunnerV2Game) => {
+				if (this.externalValue) {
+					Object.keys(this.externalValue).forEach((key) => {
+						if (key) game.external[key] = this.externalValue[key];
+					});
+				}
 				game._started.addOnce(() => resolve(game));
 			});
 		});

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -99,7 +99,7 @@ export class RunnerV2 extends Runner {
 			driver.gameCreatedTrigger.addOnce((game: RunnerV2Game) => {
 				if (this.externalValue) {
 					Object.keys(this.externalValue).forEach((key) => {
-						if (key) game.external[key] = this.externalValue[key];
+						game.external[key] = this.externalValue[key];
 					});
 				}
 				game._started.addOnce(() => resolve(game));

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -97,6 +97,11 @@ export class RunnerV3 extends Runner {
 			);
 
 			driver.gameCreatedTrigger.addOnce((game: RunnerV3Game) => {
+				if (this.externalValue) {
+					Object.keys(this.externalValue).forEach((key) => {
+						if (key) game.external[key] = this.externalValue[key];
+					});
+				}
 				game._started.addOnce(() => resolve(game));
 			});
 		});

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -99,7 +99,7 @@ export class RunnerV3 extends Runner {
 			driver.gameCreatedTrigger.addOnce((game: RunnerV3Game) => {
 				if (this.externalValue) {
 					Object.keys(this.externalValue).forEach((key) => {
-						if (key) game.external[key] = this.externalValue[key];
+						game.external[key] = this.externalValue[key];
 					});
 				}
 				game._started.addOnce(() => resolve(game));

--- a/packages/headless-driver-runner/src/Runner.ts
+++ b/packages/headless-driver-runner/src/Runner.ts
@@ -14,6 +14,7 @@ export interface RunnerParameters {
 	external?: { [key: string]: string };
 	gameArgs?: any;
 	player?: RunnerPlayer;
+	externalValue?: { [key: string]: any };
 }
 
 export type RunnerExecutionMode = "active" | "passive";
@@ -76,6 +77,10 @@ export abstract class Runner {
 
 	get external(): { [key: string]: string } | undefined {
 		return this.params.external;
+	}
+
+	get externalValue(): { [key: string]: any } {
+		return this.params.externalValue;
 	}
 
 	constructor(params: RunnerParameters) {

--- a/packages/headless-driver/src/__tests__/runSpec.ts
+++ b/packages/headless-driver/src/__tests__/runSpec.ts
@@ -52,7 +52,8 @@ describe("ホスティングされたコンテンツの動作テスト", () => {
 			amflow: activeAMFlow,
 			playToken,
 			executionMode: "active",
-			allowedUrls: null
+			allowedUrls: null,
+			externalValue: {hoge: () => "hoge1", foo: () => "foo1" }
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV1;
 		expect(runner.runnerId).toBe("0");
@@ -61,6 +62,8 @@ describe("ホスティングされたコンテンツの動作テスト", () => {
 
 		const game = (await runnerManager.startRunner(runner.runnerId)) as RunnerV1Game;
 		expect(game.playId).toBe(playId);
+		expect(game.external.hoge()).toBe("hoge1");
+		expect(game.external.foo()).toBe("foo1");
 
 		const handleData = () =>
 			new Promise<any>((resolve, reject) => {
@@ -111,7 +114,8 @@ describe("ホスティングされたコンテンツの動作テスト", () => {
 			amflow: activeAMFlow,
 			playToken,
 			executionMode: "active",
-			allowedUrls: null
+			allowedUrls: null,
+			externalValue: { hoge: () => "hoge2", foo: () => "foo2" }
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV2;
 		expect(runner.runnerId).toBe("0");
@@ -120,6 +124,8 @@ describe("ホスティングされたコンテンツの動作テスト", () => {
 
 		const game = (await runnerManager.startRunner(runner.runnerId)) as RunnerV2Game;
 		expect(game.playId).toBe(playId);
+		expect(game.external.hoge()).toBe("hoge2");
+		expect(game.external.foo()).toBe("foo2");
 
 		const handleData = () =>
 			new Promise<any>((resolve, reject) => {
@@ -167,7 +173,8 @@ describe("ホスティングされたコンテンツの動作テスト", () => {
 			amflow: activeAMFlow,
 			playToken,
 			executionMode: "active",
-			allowedUrls: null
+			allowedUrls: null,
+			externalValue: { hoge: () => "hoge3", foo: () => "foo3" }
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV3;
 		expect(runner.runnerId).toBe("0");
@@ -176,6 +183,8 @@ describe("ホスティングされたコンテンツの動作テスト", () => {
 
 		const game = (await runnerManager.startRunner(runner.runnerId)) as RunnerV3Game;
 		expect(game.playId).toBe(playId);
+		expect(game.external.hoge()).toBe("hoge3");
+		expect(game.external.foo()).toBe("foo3");
 
 		const handleData = () =>
 			new Promise<any>((resolve) => {
@@ -418,7 +427,8 @@ describe("ローカルコンテンツの動作テスト", () => {
 			amflow: activeAMFlow,
 			playToken,
 			executionMode: "active",
-			allowedUrls: null
+			allowedUrls: null,
+			externalValue: { hoge: () => "hoge1", foo: () => "foo1" }
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV2;
 		expect(runner.external).toEqual({});
@@ -433,9 +443,11 @@ describe("ローカルコンテンツの動作テスト", () => {
 			});
 
 		try {
-			await runner.start();
+			const game = await runner.start();
 			const data = await handleData();
 			expect(data).toBe("reached right");
+			expect(game.external.hoge()).toBe("hoge1");
+			expect(game.external.foo()).toBe("foo1");
 		} finally {
 			runner.stop();
 		}
@@ -453,7 +465,8 @@ describe("ローカルコンテンツの動作テスト", () => {
 			amflow: activeAMFlow,
 			playToken,
 			executionMode: "active",
-			allowedUrls: null
+			allowedUrls: null,
+			externalValue: { hoge: () => "hoge2", foo: () => "foo2" }
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV2;
 		expect(runner.external).toEqual({ ext: "0" });
@@ -466,9 +479,11 @@ describe("ローカルコンテンツの動作テスト", () => {
 				});
 			});
 
-		await runner.start();
+		const game = await runner.start();
 		const data = await handleData();
 		expect(data).toBe("reached right");
+		expect(game.external.hoge()).toBe("hoge2");
+		expect(game.external.foo()).toBe("foo2");
 		runner.stop();
 	});
 
@@ -485,7 +500,8 @@ describe("ローカルコンテンツの動作テスト", () => {
 			amflow: activeAMFlow,
 			playToken,
 			executionMode: "active",
-			allowedUrls: null
+			allowedUrls: null,
+			externalValue: { hoge: () => "hoge3", foo: () => "foo3" }
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV3;
 		expect(runner.external).toEqual({ ext: "0" });
@@ -498,9 +514,11 @@ describe("ローカルコンテンツの動作テスト", () => {
 				});
 			});
 
-		await runner.start();
+		const game = await runner.start();
 		const data = await handleData();
 		expect(data).toBe("reached right");
+		expect(game.external.hoge()).toBe("hoge3");
+		expect(game.external.foo()).toBe("foo3");
 		runner.stop();
 	});
 });

--- a/packages/headless-driver/src/__tests__/runSpec.ts
+++ b/packages/headless-driver/src/__tests__/runSpec.ts
@@ -53,7 +53,7 @@ describe("ホスティングされたコンテンツの動作テスト", () => {
 			playToken,
 			executionMode: "active",
 			allowedUrls: null,
-			externalValue: {hoge: () => "hoge1", foo: () => "foo1" }
+			externalValue: { hoge: () => "hoge1", foo: () => "foo1" }
 		});
 		const runner = runnerManager.getRunner(runnerId) as RunnerV1;
 		expect(runner.runnerId).toBe("0");

--- a/packages/headless-driver/src/runner/RunnerManager.ts
+++ b/packages/headless-driver/src/runner/RunnerManager.ts
@@ -28,7 +28,7 @@ export interface CreateRunnerParameters {
 	 */
 	allowedUrls: (string | RegExp)[] | null;
 	/**
-	 * g.Game#external に対応する。
+	 * g.Game#external に与えられる値。
 	 * g.Game#_started の発火前にセットされる。
 	 */
 	externalValue?: { [key: string]: any };

--- a/packages/headless-driver/src/runner/RunnerManager.ts
+++ b/packages/headless-driver/src/runner/RunnerManager.ts
@@ -27,6 +27,7 @@ export interface CreateRunnerParameters {
 	 * null が指定された場合は全てのアクセスを許可する。
 	 */
 	allowedUrls: (string | RegExp)[] | null;
+	externalValue?: { [key: string]: any };
 }
 
 interface EngineConfiguration {
@@ -157,7 +158,8 @@ export class RunnerManager {
 					executionMode: params.executionMode,
 					external,
 					gameArgs: params.gameArgs,
-					player: params.player
+					player: params.player,
+					externalValue: params.externalValue
 				});
 				runner.errorTrigger.addOnce((err: any) => {
 					getSystemLogger().error(err);
@@ -177,7 +179,8 @@ export class RunnerManager {
 					executionMode: params.executionMode,
 					external,
 					gameArgs: params.gameArgs,
-					player: params.player
+					player: params.player,
+					externalValue: params.externalValue
 				});
 				runner.errorTrigger.addOnce((err: any) => {
 					getSystemLogger().error(err);
@@ -197,7 +200,8 @@ export class RunnerManager {
 					executionMode: params.executionMode,
 					external,
 					gameArgs: params.gameArgs,
-					player: params.player
+					player: params.player,
+					externalValue: params.externalValue
 				});
 				runner.errorTrigger.handle((err: any) => {
 					getSystemLogger().error(err);

--- a/packages/headless-driver/src/runner/RunnerManager.ts
+++ b/packages/headless-driver/src/runner/RunnerManager.ts
@@ -27,6 +27,10 @@ export interface CreateRunnerParameters {
 	 * null が指定された場合は全てのアクセスを許可する。
 	 */
 	allowedUrls: (string | RegExp)[] | null;
+	/**
+	 * g.Game#external に対応する。
+	 * g.Game#_started の発火前にセットされる。
+	 */
 	externalValue?: { [key: string]: any };
 }
 


### PR DESCRIPTION
## 内容

headless-driverに  `game.external` を与える機能の追加。
- `Runner#RunnerParameters`, `RunnerManager#CreateRunnerParameters` に  `externalValue`を追加。
- `externalValue` が存在する場合、`game.external` に `externalValue`の内容を追加します。