### PR TITLE
【v1.1.6】内部コンポーネントの更新(engineFiles@3.0.0-beta.4, engineFiles@2.1.39, engineFiles@1.1.14)

### DIFF
--- a/packages/headless-driver-runner-v3/package.json
+++ b/packages/headless-driver-runner-v3/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/engine-files": "3.0.0-beta.3",
+    "@akashic/engine-files": "3.0.0-beta.4",
     "@akashic/headless-driver-runner": "1.1.5"
   },
   "devDependencies": {

--- a/packages/headless-driver-runner-v3/src/platform/NullGlyphFactory.ts
+++ b/packages/headless-driver-runner-v3/src/platform/NullGlyphFactory.ts
@@ -3,11 +3,11 @@ import { NullGlyph } from "./NullGlyph";
 import { NullSurface } from "./NullSurface";
 
 export class NullGlyphFactory implements g.GlyphFactoryLike {
-	fontFamily: g.FontFamily | string | (g.FontFamily | string)[];
+	fontFamily: string | string[];
 	fontSize: number;
 	baselineHeight: number;
 	fontColor: string;
-	fontWeight: g.FontWeight;
+	fontWeight: g.FontWeightString;
 	strokeWidth: number;
 	strokeColor: string;
 	strokeOnly: boolean;
@@ -15,14 +15,14 @@ export class NullGlyphFactory implements g.GlyphFactoryLike {
 	private dummySurface: g.SurfaceLike = new NullSurface(0, 0);
 
 	constructor(
-		fontFamily: g.FontFamily | string | (g.FontFamily | string)[],
+		fontFamily: string | string[],
 		fontSize: number,
 		baselineHeight: number = fontSize,
 		fontColor: string = "black",
 		strokeWidth: number = 0,
 		strokeColor: string = "black",
 		strokeOnly: boolean = false,
-		fontWeight: g.FontWeight = g.FontWeight.Normal
+		fontWeight: g.FontWeightString = "normal"
 	) {
 		this.fontFamily = fontFamily;
 		this.fontSize = fontSize;

--- a/packages/headless-driver-runner-v3/src/platform/NullRenderer.ts
+++ b/packages/headless-driver-runner-v3/src/platform/NullRenderer.ts
@@ -62,7 +62,7 @@ export class NullRenderer implements g.RendererLike {
 		//
 	}
 
-	setCompositeOperation(_operation: g.CompositeOperation): void {
+	setCompositeOperation(_operation: g.CompositeOperationString): void {
 		//
 	}
 

--- a/packages/headless-driver-runner-v3/src/platform/ResourceFactory.ts
+++ b/packages/headless-driver-runner-v3/src/platform/ResourceFactory.ts
@@ -60,14 +60,14 @@ export class ResourceFactory implements g.ResourceFactoryLike {
 	}
 
 	createGlyphFactory(
-		fontFamily: g.FontFamily | string | (g.FontFamily | string)[],
+		fontFamily: string | string[],
 		fontSize: number,
 		baselineHeight?: number,
 		fontColor?: string,
 		strokeWidth?: number,
 		strokeColor?: string,
 		strokeOnly?: boolean,
-		fontWeight?: g.FontWeight
+		fontWeight?: g.FontWeightString
 	): g.GlyphFactoryLike {
 		return new NullGlyphFactory(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight);
 	}


### PR DESCRIPTION
#137 の自動更新が失敗 (追従作業が必要) したので、対応します。 v3.0.0-beta.4 に追従したのみ。

* engineFilesV3: 3.0.0-beta.4
* engineFilesV2: 2.1.39
* engineFilesV1: 1.1.14
* amflow: 1.0.0
* playlog: 2.0.0
* trigger: 0.1.7
