### PR TITLE
fix build problem around fs.readFileSync()

### DIFF
--- a/packages/headless-driver/package.json
+++ b/packages/headless-driver/package.json
@@ -38,6 +38,7 @@
     "@types/get-port": "4.0.1",
     "@types/jest": "25.2.1",
     "@types/lodash.clonedeep": "4.5.6",
+    "@types/node": "13.13.6",
     "@types/node-fetch": "2.5.6",
     "get-port": "5.1.1",
     "jest": "25.3.0",


### PR DESCRIPTION
掲題どおり。

Node.js に依存しているものの `@types/node` を入れておらず、孫依存で勝手にバージョンが上がってビルドできなくなっていました (string が `type BufferEncoding = "utf8" | ...` に変わった模様)。

ビルドが通っていたバージョンの `@types/node` を dependencies に加えます。