### PR TITLE
publishスクリプトにタグ指定オプションを追加

### DIFF
--- a/build/publishAndUpdateChangelog.js
+++ b/build/publishAndUpdateChangelog.js
@@ -34,7 +34,8 @@ try {
 	// CHANGELOG作成時に必要になるのでpublish前のバージョンを保持しておく
 	const beforeVersion = require(path.join(__dirname, "..", "lerna.json")).version;
 	const forcePublishOption = process.env.PUBLISH_MODE === "force" ? "--force-publish=*" : "";
-	execSync(`${lernaPath} publish ${target} ${forcePublishOption} --yes`);
+	const distTagOption = process.env.TARGET_TAG ? `--dist-tag ${process.env.TARGET_TAG}` : "";
+	execSync(`${lernaPath} publish ${target} ${forcePublishOption} ${distTagOption} --yes`);
 	console.log("end to publish");
 
 	// 現在のCHANGELOGに次バージョンのログを追加

--- a/build/publishAndUpdateChangelog.js
+++ b/build/publishAndUpdateChangelog.js
@@ -34,7 +34,7 @@ try {
 	// CHANGELOG作成時に必要になるのでpublish前のバージョンを保持しておく
 	const beforeVersion = require(path.join(__dirname, "..", "lerna.json")).version;
 	const forcePublishOption = process.env.PUBLISH_MODE === "force" ? "--force-publish=*" : "";
-	const distTagOption = process.env.TARGET_TAG ? `--dist-tag ${process.env.TARGET_TAG}` : "";
+	const distTagOption = process.env.PUBLISH_DIST_TAG ? `--dist-tag ${process.env.PUBLISH_DIST_TAG}` : "";
 	execSync(`${lernaPath} publish ${target} ${forcePublishOption} ${distTagOption} --yes`);
 	console.log("end to publish");
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "publish:major": "node build/publishAndUpdateChangelog.js major",
     "publish:force-patch-all": "node build/prepareRepublish.js && cross-env PUBLISH_MODE=force node build/publishAndUpdateChangelog.js patch",
     "publish:force-minor-all": "node build/prepareRepublish.js && cross-env PUBLISH_MODE=force node build/publishAndUpdateChangelog.js minor",
-    "publish:prerelease": "lerna publish prerelease --dist-tag ${TARGET_TAG:-next} --yes",
+    "publish:prerelease": "lerna publish prerelease --dist-tag ${PUBLISH_DIST_TAG:-next} --yes",
     "build": "lerna run build",
     "test": "lerna run test && npm run lint:md",
     "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "publish:major": "node build/publishAndUpdateChangelog.js major",
     "publish:force-patch-all": "node build/prepareRepublish.js && cross-env PUBLISH_MODE=force node build/publishAndUpdateChangelog.js patch",
     "publish:force-minor-all": "node build/prepareRepublish.js && cross-env PUBLISH_MODE=force node build/publishAndUpdateChangelog.js minor",
-    "publish:prerelease": "lerna publish prerelease --dist-tag next --yes",
+    "publish:prerelease": "lerna publish prerelease --dist-tag ${TARGET_TAG:-next} --yes",
     "build": "lerna run build",
     "test": "lerna run test && npm run lint:md",
     "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc"


### PR DESCRIPTION
### 概要
* npm-scriptに記述している`publish:*`コマンドでこれまでタグの指定ができなかったので、環境変数を用いてタグの指定をできるようにしました。

### やったこと
* 環境変数`$PUBLISH_DIST_TAG`でpublish時のタグ名を指定できるようにしました
  * デフォルト値はlatest(`publish:prerelease`コマンドのみnext)
  * このコマンドはwindows環境では動かないと思われますが、windows環境でpublishする想定は無いのでこの対応で十分ではと判断しました(問題がある場合は修正します)