### PR TITLE
use jest timer in LooperSpec

### DIFF
--- a/packages/headless-driver-runner/src/__tests__/LooperSpec.ts
+++ b/packages/headless-driver-runner/src/__tests__/LooperSpec.ts
@@ -1,13 +1,9 @@
 import { Looper } from "../Looper";
 
-function sleep(duration: number): Promise<void> {
-	return new Promise((resolve, _reject) => {
-		setTimeout(resolve, duration);
-	});
-}
-
 describe("Looper", () => {
-	it("Looper#start(), stop()", async () => {
+	it("Looper#start(), stop()", () => {
+		jest.useFakeTimers();
+
 		let loopCount = 0;
 		const looper = new Looper(
 			(_delta: number) => {
@@ -20,12 +16,12 @@ describe("Looper", () => {
 		);
 
 		looper.start();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		expect(loopCount).toBeGreaterThan(10); // 500 ms あれば確実に超えるであろう値 (厳密な値は実行環境に依存する)
 
 		const count = loopCount;
 		looper.stop();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		expect(loopCount).toBe(count); // Looper#stop() 後にループ処理が実行されない
 	});
 });


### PR DESCRIPTION
## このPullRequestが解決する内容

環境によってテストが失敗するケースへの対応です。
呼び出しタイミングが保証されないsetTimeoutに替えて、jestがモックした関数を使うことで、実行時の安定化を行います。