### PR TITLE
add publish script as npm-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "publish:force-patch-all": "node build/prepareRepublish.js && cross-env PUBLISH_MODE=force node build/publishAndUpdateChangelog.js patch",
     "publish:force-minor-all": "node build/prepareRepublish.js && cross-env PUBLISH_MODE=force node build/publishAndUpdateChangelog.js minor",
     "publish:prerelease": "lerna publish prerelease --dist-tag ${PUBLISH_DIST_TAG:-next} --yes",
+    "publish:from-package": "lerna publish from-package --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
     "build": "lerna run build",
     "test": "lerna run test && npm run lint:md",
     "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc"


### PR DESCRIPTION
### やったこと
* npm-scripts に`"publish:from-package"`の追加
  * これを実行するとgithub上のpackage.jsonに記載されたversionでそのままpublishされる
    * 通常はgithub上のpackage.jsonとnpm上のversionを同時に上げるので利用しないが、github上のpackage.jsonのversionしか上がらない等トラブルが発生した時に利用する想定