### PR TITLE
`g` の名前空間を export するように

### DIFF
--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -2,6 +2,9 @@ import { akashicEngine as g, gameDriver as gdr, pdi } from "@akashic/engine-file
 import { Runner, RunnerPointEvent } from "@akashic/headless-driver-runner";
 import { PlatformV1 } from "./platform/PlatformV1";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type RunnerV1_g = typeof g;
+
 export type RunnerV1Game = g.Game;
 
 export class RunnerV1 extends Runner {
@@ -12,7 +15,6 @@ export class RunnerV1 extends Runner {
 	private fps: number | null = null;
 	private running: boolean = false;
 
-	// NOTE: 暫定的にデバッグ用として g.Game を返している
 	async start(): Promise<RunnerV1Game | null> {
 		let game: RunnerV1Game | null = null;
 
@@ -138,6 +140,10 @@ export class RunnerV1 extends Runner {
 
 	getPrimarySurface(): never {
 		throw new Error("RunnerV1#getPrimarySurface(): Not supported");
+	}
+
+	g(): RunnerV1_g {
+		return g;
 	}
 
 	private initGameDriver(): Promise<RunnerV1Game> {

--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -8,7 +8,8 @@ export type RunnerV1_g = typeof g;
 export type RunnerV1Game = g.Game;
 
 export class RunnerV1 extends Runner {
-	engineVersion: string = "1";
+	readonly engineVersion: string = "1";
+	readonly g: RunnerV1_g = g;
 
 	private driver: gdr.GameDriver | null = null;
 	private platform: PlatformV1 | null = null;
@@ -140,10 +141,6 @@ export class RunnerV1 extends Runner {
 
 	getPrimarySurface(): never {
 		throw new Error("RunnerV1#getPrimarySurface(): Not supported");
-	}
-
-	g(): RunnerV1_g {
-		return g;
 	}
 
 	private initGameDriver(): Promise<RunnerV1Game> {

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -2,6 +2,9 @@ import { akashicEngine as g, gameDriver as gdr, pdi } from "@akashic/engine-file
 import { Runner, RunnerPointEvent } from "@akashic/headless-driver-runner";
 import { PlatformV2 } from "./platform/PlatformV2";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type RunnerV2_g = typeof g;
+
 export type RunnerV2Game = g.Game;
 
 export class RunnerV2 extends Runner {
@@ -12,7 +15,6 @@ export class RunnerV2 extends Runner {
 	private fps: number | null = null;
 	private running: boolean = false;
 
-	// NOTE: 暫定的にデバッグ用として g.Game を返している
 	async start(): Promise<RunnerV2Game | null> {
 		let game: RunnerV2Game | null = null;
 
@@ -65,6 +67,10 @@ export class RunnerV2 extends Runner {
 		}
 
 		this.platform.advanceLoopers(Math.ceil(1000 / this.fps));
+	}
+
+	g(): RunnerV2_g {
+		return g;
 	}
 
 	async advance(ms: number): Promise<void> {

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -8,7 +8,8 @@ export type RunnerV2_g = typeof g;
 export type RunnerV2Game = g.Game;
 
 export class RunnerV2 extends Runner {
-	engineVersion: string = "2";
+	readonly engineVersion: string = "2";
+	readonly g: RunnerV2_g = g;
 
 	private driver: gdr.GameDriver | null = null;
 	private platform: PlatformV2 | null = null;
@@ -67,10 +68,6 @@ export class RunnerV2 extends Runner {
 		}
 
 		this.platform.advanceLoopers(Math.ceil(1000 / this.fps));
-	}
-
-	g(): RunnerV2_g {
-		return g;
 	}
 
 	async advance(ms: number): Promise<void> {

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -5,6 +5,9 @@ import type { NodeCanvasSurface } from "./platform/graphics/canvas/NodeCanvasSur
 import type { NullSurface } from "./platform/graphics/null/NullSurface";
 import { PlatformV3 } from "./platform/PlatformV3";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type RunnerV3_g = typeof g;
+
 export type RunnerV3Game = g.Game;
 
 export class RunnerV3 extends Runner {
@@ -15,7 +18,6 @@ export class RunnerV3 extends Runner {
 	private fps: number | null = null;
 	private running: boolean = false;
 
-	// NOTE: 暫定的にデバッグ用として g.Game を返している
 	async start(): Promise<RunnerV3Game | null> {
 		let game: RunnerV3Game | null = null;
 
@@ -170,6 +172,10 @@ export class RunnerV3 extends Runner {
 			throw Error("RunnerV3#getPrimarySurface(): Not supported except in the case of renderingMode === 'node-canvas");
 		}
 		return this.getPrimarySurface()._drawable;
+	}
+
+	g(): RunnerV3_g {
+		return g;
 	}
 
 	private initGameDriver(): Promise<RunnerV3Game> {

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -11,7 +11,8 @@ export type RunnerV3_g = typeof g;
 export type RunnerV3Game = g.Game;
 
 export class RunnerV3 extends Runner {
-	engineVersion: string = "3";
+	readonly engineVersion: string = "3";
+	readonly g: RunnerV3_g = g;
 
 	private driver: gdr.GameDriver | null = null;
 	private platform: PlatformV3 | null = null;
@@ -172,10 +173,6 @@ export class RunnerV3 extends Runner {
 			throw Error("RunnerV3#getPrimarySurface(): Not supported except in the case of renderingMode === 'node-canvas");
 		}
 		return this.getPrimarySurface()._drawable;
-	}
-
-	g(): RunnerV3_g {
-		return g;
 	}
 
 	private initGameDriver(): Promise<RunnerV3Game> {

--- a/packages/headless-driver-runner/src/Runner.ts
+++ b/packages/headless-driver-runner/src/Runner.ts
@@ -98,6 +98,7 @@ export abstract class Runner {
 
 	/**
 	 * Runner を開始する。
+	 * @returns `g.game` のインスタンス。起動に失敗した場合は `null` 。
 	 */
 	abstract start(): any;
 	/**
@@ -128,8 +129,14 @@ export abstract class Runner {
 	abstract firePointEvent(event: RunnerPointEvent): void;
 	/**
 	 * 実行中コンテンツのプライマリサーフェスを取得する。
+	 * @returns プライマリサーフェスのインスタンス。
 	 */
 	abstract getPrimarySurface(): any;
+	/**
+	 * g の名前空間を取得する。`g.game` は `undefined` であることに注意。
+	 * @returns `g` の名前空間のオブジェクト。
+	 */
+	 abstract g(): any;
 
 	/**
 	 * 引数に指定した関数が真を返すまでゲームの状態を進める。

--- a/packages/headless-driver-runner/src/Runner.ts
+++ b/packages/headless-driver-runner/src/Runner.ts
@@ -22,7 +22,13 @@ export interface RunnerParameters {
 }
 
 export abstract class Runner {
-	abstract engineVersion: string;
+	abstract readonly engineVersion: string;
+
+	/**
+	 * g の名前空間のオブジェクト。`g.game` は `undefined` であることに注意。
+	 */
+	abstract readonly g: any;
+
 	errorTrigger: Trigger<any> = new Trigger();
 	sendToExternalTrigger: Trigger<any> = new Trigger();
 
@@ -132,11 +138,6 @@ export abstract class Runner {
 	 * @returns プライマリサーフェスのインスタンス。
 	 */
 	abstract getPrimarySurface(): any;
-	/**
-	 * g の名前空間を取得する。`g.game` は `undefined` であることに注意。
-	 * @returns `g` の名前空間のオブジェクト。
-	 */
-	 abstract g(): any;
 
 	/**
 	 * 引数に指定した関数が真を返すまでゲームの状態を進める。

--- a/packages/headless-driver/src/__tests__/runSpec.ts
+++ b/packages/headless-driver/src/__tests__/runSpec.ts
@@ -1,7 +1,5 @@
 import * as path from "path";
-import { RunnerV1, RunnerV1Game } from "@akashic/headless-driver-runner-v1";
-import { RunnerV2, RunnerV2Game } from "@akashic/headless-driver-runner-v2";
-import { RunnerV3, RunnerV3Game } from "@akashic/headless-driver-runner-v3";
+import { RunnerV1, RunnerV1Game, RunnerV2, RunnerV2Game, RunnerV3, RunnerV3Game } from "..";
 import * as ExecuteVmScriptV1 from "../ExecuteVmScriptV1";
 import * as ExecuteVmScriptV2 from "../ExecuteVmScriptV2";
 import * as ExecuteVmScriptV3 from "../ExecuteVmScriptV3";
@@ -76,6 +74,10 @@ describe("untrusted コンテンツの動作テスト (URL)", () => {
 
 		const data = await handleData();
 		expect(data).toBe("reached right");
+
+		// インスタンスの生成元が同一であることを確認
+		expect(game instanceof runner.g().Game).toBe(true);
+		expect(game.scene() instanceof runner.g().Scene).toBe(true);
 
 		// コンテンツ側へのポイントイベントの発火が正しく機能している
 		runner.firePointEvent({
@@ -178,6 +180,10 @@ describe("untrusted コンテンツの動作テスト (URL)", () => {
 		const data = await handleData();
 		expect(data).toBe("reached right");
 
+		// インスタンスの生成元が同一であることを確認
+		expect(game instanceof runner.g().Game).toBe(true);
+		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+
 		// コンテンツ側へのポイントイベントの発火が正しく機能している
 		runner.firePointEvent({
 			type: "down",
@@ -276,6 +282,10 @@ describe("untrusted コンテンツの動作テスト (URL)", () => {
 
 		const data = await handleData();
 		expect(data).toBe("reached right");
+
+		// インスタンスの生成元が同一であることを確認
+		expect(game instanceof runner.g().Game).toBe(true);
+		expect(game.scene() instanceof runner.g().Scene).toBe(true);
 
 		// コンテンツ側へのポイントイベントの発火が正しく機能している
 		runner.firePointEvent({
@@ -562,16 +572,18 @@ describe("untrusted コンテンツの動作テスト (ローカルパス)", () 
 				});
 			});
 
-		try {
-			const game = (await runner.start())!;
-			const data = await handleData();
-			expect(data).toBe("reached right");
-			expect(game.external.hoge()).toBe("hoge1");
-			expect(game.external.foo()).toBe("foo1");
-		} finally {
-			runner.stop();
-		}
+		const game = (await runner.start())!;
+		const data = await handleData();
+		expect(data).toBe("reached right");
+		expect(game.external.hoge()).toBe("hoge1");
+		expect(game.external.foo()).toBe("foo1");
+
+		expect(game instanceof runner.g().Game).toBe(true);
+		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+
+		runner.stop();
 	});
+
 	it("ローカルの game.json から Akashic V2 コンテンツを起動できる", async () => {
 		const playManager = new PlayManager();
 		const playId = await playManager.createPlay({
@@ -604,6 +616,10 @@ describe("untrusted コンテンツの動作テスト (ローカルパス)", () 
 		expect(data).toBe("reached right");
 		expect(game.external.hoge()).toBe("hoge2");
 		expect(game.external.foo()).toBe("foo2");
+
+		expect(game instanceof runner.g().Game).toBe(true);
+		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+
 		runner.stop();
 	});
 
@@ -639,6 +655,10 @@ describe("untrusted コンテンツの動作テスト (ローカルパス)", () 
 		expect(data).toBe("reached right");
 		expect(game.external.hoge()).toBe("hoge3");
 		expect(game.external.foo()).toBe("foo3");
+
+		expect(game instanceof runner.g().Game).toBe(true);
+		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+
 		runner.stop();
 	});
 });

--- a/packages/headless-driver/src/__tests__/runSpec.ts
+++ b/packages/headless-driver/src/__tests__/runSpec.ts
@@ -76,8 +76,8 @@ describe("untrusted コンテンツの動作テスト (URL)", () => {
 		expect(data).toBe("reached right");
 
 		// インスタンスの生成元が同一であることを確認
-		expect(game instanceof runner.g().Game).toBe(true);
-		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+		expect(game instanceof runner.g.Game).toBe(true);
+		expect(game.scene() instanceof runner.g.Scene).toBe(true);
 
 		// コンテンツ側へのポイントイベントの発火が正しく機能している
 		runner.firePointEvent({
@@ -181,8 +181,8 @@ describe("untrusted コンテンツの動作テスト (URL)", () => {
 		expect(data).toBe("reached right");
 
 		// インスタンスの生成元が同一であることを確認
-		expect(game instanceof runner.g().Game).toBe(true);
-		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+		expect(game instanceof runner.g.Game).toBe(true);
+		expect(game.scene() instanceof runner.g.Scene).toBe(true);
 
 		// コンテンツ側へのポイントイベントの発火が正しく機能している
 		runner.firePointEvent({
@@ -284,8 +284,8 @@ describe("untrusted コンテンツの動作テスト (URL)", () => {
 		expect(data).toBe("reached right");
 
 		// インスタンスの生成元が同一であることを確認
-		expect(game instanceof runner.g().Game).toBe(true);
-		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+		expect(game instanceof runner.g.Game).toBe(true);
+		expect(game.scene() instanceof runner.g.Scene).toBe(true);
 
 		// コンテンツ側へのポイントイベントの発火が正しく機能している
 		runner.firePointEvent({
@@ -578,8 +578,8 @@ describe("untrusted コンテンツの動作テスト (ローカルパス)", () 
 		expect(game.external.hoge()).toBe("hoge1");
 		expect(game.external.foo()).toBe("foo1");
 
-		expect(game instanceof runner.g().Game).toBe(true);
-		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+		expect(game instanceof runner.g.Game).toBe(true);
+		expect(game.scene() instanceof runner.g.Scene).toBe(true);
 
 		runner.stop();
 	});
@@ -617,8 +617,8 @@ describe("untrusted コンテンツの動作テスト (ローカルパス)", () 
 		expect(game.external.hoge()).toBe("hoge2");
 		expect(game.external.foo()).toBe("foo2");
 
-		expect(game instanceof runner.g().Game).toBe(true);
-		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+		expect(game instanceof runner.g.Game).toBe(true);
+		expect(game.scene() instanceof runner.g.Scene).toBe(true);
 
 		runner.stop();
 	});
@@ -656,8 +656,8 @@ describe("untrusted コンテンツの動作テスト (ローカルパス)", () 
 		expect(game.external.hoge()).toBe("hoge3");
 		expect(game.external.foo()).toBe("foo3");
 
-		expect(game instanceof runner.g().Game).toBe(true);
-		expect(game.scene() instanceof runner.g().Scene).toBe(true);
+		expect(game instanceof runner.g.Game).toBe(true);
+		expect(game.scene() instanceof runner.g.Scene).toBe(true);
 
 		runner.stop();
 	});


### PR DESCRIPTION
## このPullRequestが解決する内容
akashic-engine のスクリプトアセット内で参照可能な `g` を利用側から参照できるようにします。