### PR TITLE
`Runner#platform`, `DumpedPlaylog` を公開プロパティに変更

### DIFF
--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -6,9 +6,9 @@ export type RunnerV1Game = g.Game;
 
 export class RunnerV1 extends Runner {
 	engineVersion: string = "1";
+	platform: PlatformV1 | null = null;
 
 	private driver: gdr.GameDriver | null = null;
-	private platform: PlatformV1 | null = null;
 	private fps: number | null = null;
 	private running: boolean = false;
 

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -6,9 +6,9 @@ export type RunnerV2Game = g.Game;
 
 export class RunnerV2 extends Runner {
 	engineVersion: string = "2";
+	platform: PlatformV2 | null = null;
 
 	private driver: gdr.GameDriver | null = null;
-	private platform: PlatformV2 | null = null;
 	private fps: number | null = null;
 	private running: boolean = false;
 

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -9,9 +9,9 @@ export type RunnerV3Game = g.Game;
 
 export class RunnerV3 extends Runner {
 	engineVersion: string = "3";
+	platform: PlatformV3 | null = null;
 
 	private driver: gdr.GameDriver | null = null;
-	private platform: PlatformV3 | null = null;
 	private fps: number | null = null;
 	private running: boolean = false;
 

--- a/packages/headless-driver-runner/src/Runner.ts
+++ b/packages/headless-driver-runner/src/Runner.ts
@@ -1,5 +1,6 @@
 import { AMFlow } from "@akashic/amflow";
 import { Trigger } from "@akashic/trigger";
+import { Platform } from "./Platform";
 import { RunnerAdvanceConditionFunc, RunnerExecutionMode, RunnerPlayer, RunnerPointEvent, RunnerRenderingMode } from "./types";
 
 export interface RunnerParameters {
@@ -23,7 +24,8 @@ export interface RunnerParameters {
 
 export abstract class Runner {
 	abstract engineVersion: string;
-	errorTrigger: Trigger<any> = new Trigger();
+	abstract platform: Platform | null;
+	errorTrigger: Trigger<Error> = new Trigger();
 	sendToExternalTrigger: Trigger<any> = new Trigger();
 
 	private params: RunnerParameters;

--- a/packages/headless-driver/src/index.ts
+++ b/packages/headless-driver/src/index.ts
@@ -2,6 +2,7 @@ export * from "./play/amflow/AMFlowClient";
 export * from "./play/Content";
 export * from "./play/Play";
 export * from "./play/AMFlowClientManager";
+export * from "./play/amflow/types";
 export * from "./play/PlayManager";
 export * from "./runner/RunnerManager";
 export * from "./Logger";

--- a/packages/headless-driver/src/play/PlayManager.ts
+++ b/packages/headless-driver/src/play/PlayManager.ts
@@ -1,6 +1,6 @@
 import { Permission } from "@akashic/amflow";
 import { AMFlowClient } from "./amflow/AMFlowClient";
-import { DumpedPlaylog } from "./amflow/AMFlowStore";
+import { DumpedPlaylog } from "./amflow/types";
 import { AMFlowClientManager } from "./AMFlowClientManager";
 import { ContentLocation } from "./Content";
 import { Play, PlayStatus } from "./Play";

--- a/packages/headless-driver/src/play/amflow/AMFlowClient.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowClient.ts
@@ -1,8 +1,9 @@
 import { AMFlow, GetStartPointOptions, GetTickListOptions, Permission, StartPoint } from "@akashic/amflow";
 import { Event, EventFlagsMask, EventIndex, StorageData, StorageKey, StorageReadKey, StorageValue, Tick, TickList } from "@akashic/playlog";
 import { getSystemLogger } from "../../Logger";
-import { AMFlowStore, DumpedPlaylog } from "./AMFlowStore";
+import { AMFlowStore } from "./AMFlowStore";
 import { createError } from "./ErrorFactory";
+import { DumpedPlaylog } from "./types";
 
 export type AMFlowState = "connecting" | "open" | "closing" | "closed";
 

--- a/packages/headless-driver/src/play/amflow/AMFlowStore.ts
+++ b/packages/headless-driver/src/play/amflow/AMFlowStore.ts
@@ -4,11 +4,7 @@ import { Trigger } from "@akashic/trigger";
 import { sha256 } from "js-sha256";
 import cloneDeep = require("lodash.clonedeep");
 import { createError } from "./ErrorFactory";
-
-export interface DumpedPlaylog {
-	tickList: TickList | null;
-	startPoints: StartPoint[];
-}
+import { DumpedPlaylog } from "./types";
 
 /**
  * AMFlow のストア。

--- a/packages/headless-driver/src/play/amflow/types.ts
+++ b/packages/headless-driver/src/play/amflow/types.ts
@@ -1,0 +1,7 @@
+import { StartPoint } from "@akashic/amflow";
+import { TickList } from "@akashic/playlog";
+
+export interface DumpedPlaylog {
+	tickList: TickList | null;
+	startPoints: StartPoint[];
+}


### PR DESCRIPTION
## このPullRequestが解決する内容
* `Runner#platform` を公開プロパティに変更します。これにより利用側で `ResourceFactory ` へアクセスすることが可能になります。
* `DumpedPlaylog` を export します。

## 破壊的変更
なし