### PR TITLE
`Runner#advanceUntil()` の挙動を修正

### DIFF
--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -70,6 +70,19 @@ export class RunnerV1 extends Runner {
 		this.platform.advanceLoopers(Math.ceil(1000 / this.fps));
 	}
 
+	protected _stepHalf(): void {
+		if (this.fps == null || this.platform == null) {
+			this.errorTrigger.fire(new Error("RunnerV1#_stepHalf(): Cannot call Runner#step() before initialized"));
+			return;
+		}
+		if (this.running) {
+			this.errorTrigger.fire(new Error("RunnerV1#_stepHalf(): Cannot call Runner#step() in running"));
+			return;
+		}
+
+		this.platform.advanceLoopers(1000 / this.fps / 2);
+	}
+
 	async advance(ms: number): Promise<void> {
 		if (this.fps == null || this.platform == null || this.driver == null) {
 			this.errorTrigger.fire(new Error("Cannot call Runner#advance() before initialized"));

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -143,6 +143,19 @@ export class RunnerV2 extends Runner {
 		throw new Error("RunnerV2#getPrimarySurface(): Not supported");
 	}
 
+	protected _stepHalf(): void {
+		if (this.fps == null || this.platform == null) {
+			this.errorTrigger.fire(new Error("RunnerV2#_stepHalf(): Cannot call Runner#step() before initialized"));
+			return;
+		}
+		if (this.running) {
+			this.errorTrigger.fire(new Error("RunnerV2#_stepHalf(): Cannot call Runner#step() in running"));
+			return;
+		}
+
+		this.platform.advanceLoopers(1000 / this.fps / 2);
+	}
+
 	private initGameDriver(): Promise<RunnerV2Game> {
 		return new Promise<RunnerV2Game>((resolve, reject) => {
 			if (this.driver) {

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -175,6 +175,19 @@ export class RunnerV3 extends Runner {
 		return this.getPrimarySurface()._drawable;
 	}
 
+	protected _stepHalf(): void {
+		if (this.fps == null || this.platform == null) {
+			this.errorTrigger.fire(new Error("RunnerV3#_stepHalf(): Cannot call Runner#step() before initialized"));
+			return;
+		}
+		if (this.running) {
+			this.errorTrigger.fire(new Error("RunnerV3#_stepHalf(): Cannot call Runner#step() in running"));
+			return;
+		}
+
+		this.platform.advanceLoopers(1000 / this.fps / 2);
+	}
+
 	private initGameDriver(): Promise<RunnerV3Game> {
 		return new Promise<RunnerV3Game>((resolve, reject) => {
 			if (this.driver) {

--- a/packages/headless-driver-runner/src/Runner.ts
+++ b/packages/headless-driver-runner/src/Runner.ts
@@ -157,7 +157,9 @@ export abstract class Runner {
 				}
 				try {
 					if (condition()) return void resolve();
-					this.step();
+					// NOTE: 現状 PDI の API 仕様により this.step() では厳密なフレーム更新ができない。そこで、一フレームの 1/2 の時間で進行することでフレームが飛んでしまうことを防止する。
+					// TODO: this.step() が厳密に一フレーム進めることができればそちらに移行
+					this._stepHalf();
 				} catch (e) {
 					return void reject(e);
 				}
@@ -166,6 +168,8 @@ export abstract class Runner {
 			handler();
 		});
 	}
+
+	protected abstract _stepHalf(): void;
 
 	protected onError(error: Error): void {
 		this.stop();


### PR DESCRIPTION
## このPullRequestが解決する内容
現状の PDI の API 仕様では `this.step()` による厳密なフレーム進行ができない。そこで、暫定的に `Runner#advanceUntil()`の内部で 1/2 フレームの時間ごとに step することでフレームが飛んでしまうことを防止する。