### PR TITLE
Add Runner#initialize()

### DIFF
--- a/packages/headless-driver-runner-v1/src/platform/PlatformV1.ts
+++ b/packages/headless-driver-runner-v1/src/platform/PlatformV1.ts
@@ -9,6 +9,7 @@ export class PlatformV1 extends Platform implements pdi.Platform {
 	private primarySurface: g.Surface | null = null;
 	private eventHandler: pdi.PlatformEventHandler | null = null;
 	private loopers: Looper[] = [];
+	private _isLooperPaused: boolean = false;
 
 	constructor(param: PlatformParameters) {
 		super(param);
@@ -40,23 +41,29 @@ export class PlatformV1 extends Platform implements pdi.Platform {
 
 	createLooper(fun: (deltaTime: number) => number): Looper {
 		const looper = new Looper(fun, (e: Error) => this.errorHandler(e));
+		if (this._isLooperPaused) {
+			looper.debugStop();
+		}
 		this.loopers.push(looper);
 		return looper;
 	}
 
 	advanceLoopers(ms: number): void {
+		this._isLooperPaused = true;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStep(ms);
 		}
 	}
 
 	pauseLoopers(): void {
+		this._isLooperPaused = true;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStop();
 		}
 	}
 
 	resumeLoopers(): void {
+		this._isLooperPaused = false;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStart();
 		}

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -15,17 +15,47 @@ export class RunnerV2 extends Runner {
 	private driver: gdr.GameDriver | null = null;
 	private fps: number | null = null;
 	private running: boolean = false;
+	private _isGameStarted: boolean = false;
+	private _isInitializeCalled: boolean = false;
+	private _isStartCalled: boolean = false;
+	private _startWaitPromise: any;
 
-	async start(): Promise<RunnerV2Game | null> {
+	async initialize(): Promise<RunnerV2Game | null> {
+		this._startWaitPromise = this.createWaitPromise();
 		let game: RunnerV2Game | null = null;
 
 		try {
 			game = await this.initGameDriver();
-			this.running = true;
+			this._isInitializeCalled = true;
 		} catch (e) {
 			this.onError(e);
 		}
+		return game;
+	}
 
+	async start(): Promise<RunnerV2Game | null> {
+		if (this._isStartCalled) {
+			this.onError(new Error("Start() has already been called."));
+		}
+		this._isStartCalled = true;
+
+		let game: RunnerV2Game | null = null;
+		if (!this._isInitializeCalled) {
+			game = await this.initialize();
+		} else {
+			game = this.driver?._game!;
+		}
+
+		if (!game) {
+			return game;
+		}
+
+		this.running = true;
+		this.platform?.resumeLoopers();
+		if (this._isGameStarted) {
+			return game;
+		}
+		await this._startWaitPromise.promise;
 		return game;
 	}
 
@@ -210,7 +240,9 @@ export class RunnerV2 extends Runner {
 						reject(e);
 						return;
 					}
+					this.platform?.pauseLoopers();
 					driver.startGame();
+					resolve(driver._game!);
 				}
 			);
 
@@ -221,7 +253,10 @@ export class RunnerV2 extends Runner {
 					});
 				}
 				this.fps = game.fps;
-				game._started.addOnce(() => resolve(game));
+				game._started.addOnce(() => {
+					this._isGameStarted = true;
+					this._startWaitPromise.resolve();
+				});
 			});
 		});
 	}

--- a/packages/headless-driver-runner-v2/src/platform/PlatformV2.ts
+++ b/packages/headless-driver-runner-v2/src/platform/PlatformV2.ts
@@ -9,6 +9,7 @@ export class PlatformV2 extends Platform implements pdi.Platform {
 	private primarySurface: g.Surface | null = null;
 	private eventHandler: pdi.PlatformEventHandler | null = null;
 	private loopers: Looper[] = [];
+	private _isLooperPaused: boolean = false;
 
 	constructor(param: PlatformParameters) {
 		super(param);
@@ -44,23 +45,29 @@ export class PlatformV2 extends Platform implements pdi.Platform {
 
 	createLooper(fun: (deltaTime: number) => number): Looper {
 		const looper = new Looper(fun, (e: Error) => this.errorHandler(e));
+		if (this._isLooperPaused) {
+			looper.debugStop();
+		}
 		this.loopers.push(looper);
 		return looper;
 	}
 
 	advanceLoopers(ms: number): void {
+		this._isLooperPaused = true;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStep(ms);
 		}
 	}
 
 	pauseLoopers(): void {
+		this._isLooperPaused = true;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStop();
 		}
 	}
 
 	resumeLoopers(): void {
+		this._isLooperPaused = false;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStart();
 		}

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -19,16 +19,47 @@ export class RunnerV3 extends Runner {
 	private fps: number | null = null;
 	private running: boolean = false;
 
-	async start(): Promise<RunnerV3Game | null> {
+	private _isGameStarted: boolean = false;
+	private _isInitializeCalled: boolean = false;
+	private _isStartCalled: boolean = false;
+	private _startWaitPromise: any;
+
+	async initialize(): Promise<RunnerV3Game | null> {
+		this._startWaitPromise = this.createWaitPromise();
 		let game: RunnerV3Game | null = null;
 
 		try {
 			game = await this.initGameDriver();
-			this.running = true;
+			this._isInitializeCalled = true;
 		} catch (e) {
 			this.onError(e);
 		}
+		return game;
+	}
 
+	async start(): Promise<RunnerV3Game | null> {
+		if (this._isStartCalled) {
+			this.onError(new Error("Start() has already been called."));
+		}
+		this._isStartCalled = true;
+
+		let game: RunnerV3Game | null = null;
+		if (!this._isInitializeCalled) {
+			game = await this.initialize();
+		} else {
+			game = this.driver?._game!;
+		}
+
+		if (!game) {
+			return game;
+		}
+
+		this.running = true;
+		this.platform?.resumeLoopers();
+		if (this._isGameStarted) {
+			return game;
+		}
+		await this._startWaitPromise.promise;
 		return game;
 	}
 
@@ -242,7 +273,9 @@ export class RunnerV3 extends Runner {
 						reject(e);
 						return;
 					}
+					this.platform?.pauseLoopers();
 					driver.startGame();
+					resolve(driver._game!);
 				}
 			);
 
@@ -253,7 +286,10 @@ export class RunnerV3 extends Runner {
 					});
 				}
 				this.fps = game.fps;
-				game._onStart.addOnce(() => resolve(game));
+				game._onStart.addOnce(() => {
+					this._isGameStarted = true;
+					this._startWaitPromise.resolve();
+				});
 			});
 		});
 	}

--- a/packages/headless-driver-runner-v3/src/platform/PlatformV3.ts
+++ b/packages/headless-driver-runner-v3/src/platform/PlatformV3.ts
@@ -8,6 +8,7 @@ export class PlatformV3 extends Platform implements pdi.Platform {
 	private primarySurface: g.Surface | null = null;
 	private eventHandler: pdi.PlatformEventHandler | null = null;
 	private loopers: Looper[] = [];
+	private _isLooperPaused: boolean = false;
 
 	constructor(param: PlatformParameters) {
 		super(param);
@@ -65,23 +66,29 @@ export class PlatformV3 extends Platform implements pdi.Platform {
 
 	createLooper(fun: (deltaTime: number) => number): Looper {
 		const looper = new Looper(fun, (e: Error) => this.errorHandler(e));
+		if (this._isLooperPaused) {
+			looper.debugStop();
+		}
 		this.loopers.push(looper);
 		return looper;
 	}
 
 	advanceLoopers(ms: number): void {
+		this._isLooperPaused = true;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStep(ms);
 		}
 	}
 
 	pauseLoopers(): void {
+		this._isLooperPaused = true;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStop();
 		}
 	}
 
 	resumeLoopers(): void {
+		this._isLooperPaused = false;
 		for (let i = 0; i < this.loopers.length; i++) {
 			this.loopers[i].debugStart();
 		}

--- a/packages/headless-driver-runner/src/Runner.ts
+++ b/packages/headless-driver-runner/src/Runner.ts
@@ -107,6 +107,11 @@ export abstract class Runner {
 	}
 
 	/**
+	 * Runner を初期化する。
+	 * @returns `g.game` のインスタンス。初期化に失敗した場合は `null` 。
+	 */
+	abstract initialize(): any;
+	/**
 	 * Runner を開始する。
 	 * @returns `g.game` のインスタンス。起動に失敗した場合は `null` 。
 	 */
@@ -174,5 +179,13 @@ export abstract class Runner {
 	protected onError(error: Error): void {
 		this.stop();
 		this.errorTrigger.fire(error);
+	}
+
+	protected createWaitPromise(): { promise: Promise<void>; resolve: any } {
+		let resolve: ((value: void) => void) | null = null;
+		const promise = new Promise<void>((_ressolve, _reject) => {
+			resolve = _ressolve;
+		});
+		return { promise, resolve };
 	}
 }

--- a/packages/headless-driver/src/__tests__/renderer.spec.ts
+++ b/packages/headless-driver/src/__tests__/renderer.spec.ts
@@ -53,8 +53,7 @@ describe("コンテンツのレンダリングテスト", () => {
 			return `frame_${("000" + index).slice(-3)}.png`;
 		};
 
-		const game = (await runner.start()) as RunnerV3Game;
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV3Game;
 		await runner.advanceUntil(() => game.scene()!.name === "content-v3-entry-scene");
 
 		const width = game.width;

--- a/packages/headless-driver/src/__tests__/runner.spec.ts
+++ b/packages/headless-driver/src/__tests__/runner.spec.ts
@@ -558,7 +558,6 @@ describe("Runner の動作確認 (異常系)", () => {
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 		let err: any;
 		runner.errorTrigger.add((e) => {
-			console.log("***", e);
 			err = e;
 		});
 		await runner.start();

--- a/packages/headless-driver/src/__tests__/runner.spec.ts
+++ b/packages/headless-driver/src/__tests__/runner.spec.ts
@@ -85,11 +85,11 @@ describe("Runner の動作確認 (v1)", () => {
 		});
 
 		// step() を呼び出すたびに g.Scene#onUpdate が発火することを確認
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update"]);
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update"]);
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update", "scene_update"]);
 
 		runner.stop();
@@ -188,11 +188,11 @@ describe("Runner の動作確認 (v2)", () => {
 		});
 
 		// step() を呼び出すたびに g.Scene#onUpdate が発火することを確認
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update"]);
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update"]);
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update", "scene_update"]);
 
 		runner.stop();
@@ -299,11 +299,11 @@ describe("Runner の動作確認 (v3)", () => {
 		});
 
 		// step() を呼び出すたびに g.Scene#onUpdate が発火することを確認
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update"]);
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update"]);
-		await runner.step();
+		runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update", "scene_update"]);
 
 		runner.stop();

--- a/packages/headless-driver/src/__tests__/runner.spec.ts
+++ b/packages/headless-driver/src/__tests__/runner.spec.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
-import { RunnerV1 } from "@akashic/headless-driver-runner-v1";
-import { RunnerV2 } from "@akashic/headless-driver-runner-v2";
-import { RunnerV3 } from "@akashic/headless-driver-runner-v3";
+import { RunnerV1, RunnerV1Game } from "@akashic/headless-driver-runner-v1";
+import { RunnerV2, RunnerV2Game } from "@akashic/headless-driver-runner-v2";
+import { RunnerV3, RunnerV3Game } from "@akashic/headless-driver-runner-v3";
 import * as ExecuteVmScriptV1 from "../ExecuteVmScriptV1";
 import * as ExecuteVmScriptV2 from "../ExecuteVmScriptV2";
 import * as ExecuteVmScriptV3 from "../ExecuteVmScriptV3";
@@ -17,18 +17,13 @@ const gameJsonUrlV2 = process.env.GAME_JSON_URL_V2!;
 const gameJsonUrlV3 = process.env.GAME_JSON_URL_V3!;
 
 setSystemLogger(new SilentLogger());
+jest.useFakeTimers();
 
 beforeAll(() => {
 	jest.spyOn(ExecuteVmScriptV1, "getFilePath").mockReturnValue(path.resolve(__dirname, "../../lib/", "ExecuteVmScriptV1.js"));
 	jest.spyOn(ExecuteVmScriptV2, "getFilePath").mockReturnValue(path.resolve(__dirname, "../../lib/", "ExecuteVmScriptV2.js"));
 	jest.spyOn(ExecuteVmScriptV3, "getFilePath").mockReturnValue(path.resolve(__dirname, "../../lib/", "ExecuteVmScriptV3.js"));
 });
-
-function sleep(duration: number): Promise<void> {
-	return new Promise((resolve, _reject) => {
-		setTimeout(resolve, duration);
-	});
-}
 
 async function readyRunner(gameJsonPath: string): Promise<(RunnerV1 | RunnerV2 | RunnerV3) | null> {
 	const playManager = new PlayManager();
@@ -62,20 +57,17 @@ describe("Runner の動作確認 (v1)", () => {
 			if (l === "scene_update") updateLogs.push(l);
 		});
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV1Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v1-entry-scene");
 
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		expect(updateLogs.length).toBe(0);
 
-		runner.resume();
-
-		await sleep(500);
-		runner.pause();
+		await runner.advance(500);
 		const logCount = updateLogs.length;
 		expect(logCount).toBeGreaterThan(10); // 500ms + 30fps で必ず進むであろうフレーム数
 
-		await sleep(100);
+		await runner.advance(100);
 		expect(updateLogs.length).toBeGreaterThanOrEqual(logCount); // 停止したままであることを確認
 
 		runner.stop();
@@ -84,8 +76,8 @@ describe("Runner の動作確認 (v1)", () => {
 	it("Runner#step() で 1 ティックごとにコンテンツが進行できる", async () => {
 		const runner = (await readyRunner(gameJsonUrlV1)) as RunnerV1;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV1Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v1-entry-scene");
 
 		const logs: string[] = [];
 		runner.sendToExternalTrigger.add((l) => {
@@ -106,8 +98,8 @@ describe("Runner の動作確認 (v1)", () => {
 	it("Runner#advance() でコンテンツが進行できる (1000 ms)", async () => {
 		const runner = (await readyRunner(gameJsonUrlV1)) as RunnerV1;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV1Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v1-entry-scene");
 
 		const updateLogs: string[] = [];
 		runner.sendToExternalTrigger.add((l) => {
@@ -124,8 +116,8 @@ describe("Runner の動作確認 (v1)", () => {
 	it("Runner#advance() でコンテンツが進行できる (60 s)", async () => {
 		const runner = (await readyRunner(gameJsonUrlV1)) as RunnerV1;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV1Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v1-entry-scene");
 
 		const updateLogs: string[] = [];
 		runner.sendToExternalTrigger.add((l) => {
@@ -136,6 +128,25 @@ describe("Runner の動作確認 (v1)", () => {
 		await runner.advance(1000 * 60); // 60秒 (60 * 30フレーム) だけ進行
 		expect(updateLogs.length).toBe(60 * 30);
 
+		runner.stop();
+	});
+
+	it("Runner#initialize() ではコンテンツは進行せず、start() で進行できる", async () => {
+		const runner = (await readyRunner(gameJsonUrlV1)) as RunnerV1;
+		const game = (await runner.initialize()) as RunnerV1Game;
+		const initSceneName = game.scene()!.name;
+
+		const updateLogs: string[] = [];
+		runner.sendToExternalTrigger.add((l) => {
+			if (l === "scene_update") updateLogs.push(l);
+		});
+
+		jest.advanceTimersByTime(500);
+		expect(updateLogs.length).toBe(0);
+
+		await runner.start();
+		expect(game.scene()!.name).not.toBe(initSceneName);
+		expect(game.scene()!.name).toBe("content-v1-entry-scene");
 		runner.stop();
 	});
 });
@@ -149,20 +160,17 @@ describe("Runner の動作確認 (v2)", () => {
 			if (l === "scene_update") updateLogs.push(l);
 		});
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV2Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v2-entry-scene");
 
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		expect(updateLogs.length).toBe(0);
 
-		runner.resume();
-
-		await sleep(500);
-		runner.pause();
+		await runner.advance(500);
 		const logCount = updateLogs.length;
 		expect(logCount).toBeGreaterThan(10); // 500ms + 30fps で必ず進むであろうフレーム数
 
-		await sleep(100);
+		await runner.advance(100);
 		expect(updateLogs.length).toBeGreaterThanOrEqual(logCount); // 停止したままであることを確認
 
 		runner.stop();
@@ -171,8 +179,8 @@ describe("Runner の動作確認 (v2)", () => {
 	it("Runner#step() で 1 ティックごとにコンテンツが進行できる", async () => {
 		const runner = (await readyRunner(gameJsonUrlV2)) as RunnerV2;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV2Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v2-entry-scene");
 
 		const logs: string[] = [];
 		runner.sendToExternalTrigger.add((l) => {
@@ -193,8 +201,8 @@ describe("Runner の動作確認 (v2)", () => {
 	it("Runner#advance() でコンテンツが進行できる (1000 ms)", async () => {
 		const runner = (await readyRunner(gameJsonUrlV2)) as RunnerV2;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV2Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v2-entry-scene");
 
 		const updateLogs: string[] = [];
 		const skippingLogs: string[] = [];
@@ -215,8 +223,8 @@ describe("Runner の動作確認 (v2)", () => {
 	it("Runner#advance() でコンテンツが進行できる (60 s)", async () => {
 		const runner = (await readyRunner(gameJsonUrlV2)) as RunnerV2;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV2Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v2-entry-scene");
 
 		const updateLogs: string[] = [];
 		const skippingLogs: string[] = [];
@@ -231,6 +239,25 @@ describe("Runner の動作確認 (v2)", () => {
 		expect(updateLogs.length).toBe(60 * 30);
 		expect(skippingLogs).toEqual(["start_skipping", "end_skipping"]); // start と end のペアが一度だけなのを確認
 
+		runner.stop();
+	});
+
+	it("Runner#initialize() ではコンテンツは進行せず、start() で進行できる", async () => {
+		const runner = (await readyRunner(gameJsonUrlV2)) as RunnerV2;
+		const game = (await runner.initialize()) as RunnerV2Game;
+		const initSceneName = game.scene()!.name;
+
+		const updateLogs: string[] = [];
+		runner.sendToExternalTrigger.add((l) => {
+			if (l === "scene_update") updateLogs.push(l);
+		});
+
+		jest.advanceTimersByTime(500);
+		expect(updateLogs.length).toBe(0);
+
+		await runner.start();
+		expect(game.scene()!.name).not.toBe(initSceneName);
+		expect(game.scene()!.name).toBe("content-v2-entry-scene");
 		runner.stop();
 	});
 });
@@ -244,20 +271,17 @@ describe("Runner の動作確認 (v3)", () => {
 			if (l === "scene_update") updateLogs.push(l);
 		});
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV3Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v3-entry-scene");
 
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		expect(updateLogs.length).toBe(0);
 
-		runner.resume();
-
-		await sleep(500);
-		runner.pause();
+		await runner.advance(500);
 		const logCount = updateLogs.length;
 		expect(logCount).toBeGreaterThan(10); // 500ms + 30fps で必ず進むであろうフレーム数
 
-		await sleep(100);
+		await runner.advance(100);
 		expect(updateLogs.length).toBeGreaterThanOrEqual(logCount); // 停止したままであることを確認
 
 		runner.stop();
@@ -266,8 +290,8 @@ describe("Runner の動作確認 (v3)", () => {
 	it("Runner#step() で 1 ティックごとにコンテンツが進行できる", async () => {
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV3Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v3-entry-scene");
 
 		const logs: string[] = [];
 		runner.sendToExternalTrigger.add((l) => {
@@ -275,11 +299,11 @@ describe("Runner の動作確認 (v3)", () => {
 		});
 
 		// step() を呼び出すたびに g.Scene#onUpdate が発火することを確認
-		runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update"]);
-		runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update"]);
-		runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update", "scene_update"]);
 
 		runner.stop();
@@ -288,8 +312,8 @@ describe("Runner の動作確認 (v3)", () => {
 	it("Runner#advance() でコンテンツが進行できる (1000 ms)", async () => {
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV3Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v3-entry-scene");
 
 		const updateLogs: string[] = [];
 		const skippingLogs: string[] = [];
@@ -310,8 +334,8 @@ describe("Runner の動作確認 (v3)", () => {
 	it("Runner#advance() でコンテンツが進行できる (60 s)", async () => {
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV3Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v3-entry-scene");
 
 		const updateLogs: string[] = [];
 		const skippingLogs: string[] = [];
@@ -326,6 +350,25 @@ describe("Runner の動作確認 (v3)", () => {
 		expect(updateLogs.length).toBe(60 * 30);
 		expect(skippingLogs).toEqual(["start_skipping", "end_skipping"]); // start と end のペアが一度だけなのを確認
 
+		runner.stop();
+	});
+
+	it("Runner#initialize() ではコンテンツは進行せず、start() で進行できる", async () => {
+		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
+		const game = (await runner.initialize()) as RunnerV3Game;
+		const initSceneName = game.scene()!.name;
+
+		const updateLogs: string[] = [];
+		runner.sendToExternalTrigger.add((l) => {
+			if (l === "scene_update") updateLogs.push(l);
+		});
+
+		jest.advanceTimersByTime(500);
+		expect(updateLogs.length).toBe(0);
+
+		await runner.start();
+		expect(game.scene()!.name).not.toBe(initSceneName);
+		expect(game.scene()!.name).toBe("content-v3-entry-scene");
 		runner.stop();
 	});
 });
@@ -352,8 +395,8 @@ describe("Runner の engine-files 上書き動作確認", () => {
 
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV3Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v3-entry-scene");
 
 		const logs: string[] = [];
 		runner.sendToExternalTrigger.add((l) => {
@@ -382,8 +425,8 @@ describe("Runner の engine-files 上書き動作確認", () => {
 
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 
-		await runner.start();
-		runner.pause();
+		const game = (await runner.initialize()) as RunnerV3Game;
+		await runner.advanceUntil(() => game.scene()!.name === "content-v3-entry-scene");
 
 		const logs: string[] = [];
 		runner.sendToExternalTrigger.add((l) => {
@@ -401,10 +444,10 @@ describe("Runner の engine-files 上書き動作確認", () => {
 });
 
 describe("Runner の動作確認 (異常系)", () => {
-	it("(v1) Runner#pause() せずに Runner#advance() を呼ぶことはできない", async () => {
+	it("(v1) Runner#start() 後に pause() せずに Runner#advance() を呼ぶことはできない", async () => {
 		const runner = (await readyRunner(gameJsonUrlV1)) as RunnerV1;
 		await runner.start();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		let err: any;
 		runner.errorTrigger.add((e) => {
 			err = e;
@@ -415,10 +458,10 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.stop();
 	});
 
-	it("(v1) Runner#pause() せずに Runner#step() を呼ぶことはできない", async () => {
+	it("(v1) Runner#start() 後に pause() せずに Runner#step() を呼ぶことはできない", async () => {
 		const runner = (await readyRunner(gameJsonUrlV1)) as RunnerV1;
 		await runner.start();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		let err: any;
 		runner.errorTrigger.add((e) => {
 			err = e;
@@ -429,10 +472,23 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.stop();
 	});
 
-	it("(v2) Runner#pause() せずに Runner#advance() を呼ぶことはできない", async () => {
+	it("(v1) Runner#start() を 2回 を呼ぶことはできない", async () => {
+		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV1;
+		let err: any;
+		runner.errorTrigger.add((e) => {
+			err = e;
+		});
+		await runner.start();
+		jest.advanceTimersByTime(500);
+		await runner.start();
+		// trigger 経由でエラーが通知されることを確認
+		expect(err).not.toBeUndefined();
+	});
+
+	it("(v2) Runner#start() 後に pause() せずに Runner#advance() を呼ぶことはできない", async () => {
 		const runner = (await readyRunner(gameJsonUrlV2)) as RunnerV2;
 		await runner.start();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		let err: any;
 		runner.errorTrigger.add((e) => {
 			err = e;
@@ -443,10 +499,10 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.stop();
 	});
 
-	it("(v2) Runner#pause() せずに Runner#step() を呼ぶことはできない", async () => {
+	it("(v2) Runner#start() 後に pause() せずに Runner#step() を呼ぶことはできない", async () => {
 		const runner = (await readyRunner(gameJsonUrlV2)) as RunnerV2;
 		await runner.start();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		let err: any;
 		runner.errorTrigger.add((e) => {
 			err = e;
@@ -457,10 +513,23 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.stop();
 	});
 
-	it("(v3) Runner#pause() せずに Runner#advance() を呼ぶことはできない", async () => {
+	it("(v2) Runner#start() を 2回 を呼ぶことはできない", async () => {
+		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV2;
+		let err: any;
+		runner.errorTrigger.add((e) => {
+			err = e;
+		});
+		await runner.start();
+		jest.advanceTimersByTime(500);
+		await runner.start();
+		// trigger 経由でエラーが通知されることを確認
+		expect(err).not.toBeUndefined();
+	});
+
+	it("(v3) Runner#start() 後に pause() せずに Runner#advance() を呼ぶことはできない", async () => {
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 		await runner.start();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		let err: any;
 		runner.errorTrigger.add((e) => {
 			err = e;
@@ -471,10 +540,10 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.stop();
 	});
 
-	it("(v3) Runner#pause() せずに Runner#step() を呼ぶことはできない", async () => {
+	it("(v3) Runner#start() 後に pause() せずに Runner#step() を呼ぶことはできない", async () => {
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 		await runner.start();
-		await sleep(500);
+		jest.advanceTimersByTime(500);
 		let err: any;
 		runner.errorTrigger.add((e) => {
 			err = e;
@@ -483,5 +552,19 @@ describe("Runner の動作確認 (異常系)", () => {
 		// trigger 経由でエラーが通知されることを確認
 		expect(err).not.toBeUndefined();
 		runner.stop();
+	});
+
+	it("(v3) Runner#start() を 2回 を呼ぶことはできない", async () => {
+		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
+		let err: any;
+		runner.errorTrigger.add((e) => {
+			console.log("***", e);
+			err = e;
+		});
+		await runner.start();
+		jest.advanceTimersByTime(500);
+		await runner.start();
+		// trigger 経由でエラーが通知されることを確認
+		expect(err).not.toBeUndefined();
 	});
 });


### PR DESCRIPTION
## 概要

`Runner#initialize()` を追加します。
`initialize()` の追加により、`Runner#start()` , spec ファイルも修正。


**修正内容**
- `Runner#initialize()` 
  - game-driver#initialize()`を実行し、`looper` の進行を止めた状態で `Game` を返します。
- `Runner#start()` 
  -  `initialize()` が未実行の場合、`initialize()` を実行し、`looper` 進行させます。
  - 多重呼び出し時にはエラーとします。
  - `game._onStart` の発火が start() の完了となるため、`start()` 内では promise で wait し、`game._onStart` では wait している Promise の resolve を呼びます。
    - `start()` した場合は looper が進行し、`game._onStart` が通知されますが、`start()` せず、`advance()` 等で進行を進めた場合にも `game._onStart` は通知されます。
 - Looper
   - `_isLooperPaused: boolean` の追加。
     - 新たに `looper` を生成した時、進行が停止していたら、停止した状態の `looper` を返す。  
- spec の修正 (CI 環境で正常にテストが通る事を確認済み)
  - CI 環境でのみ、headless-driver のテストがエラーとなるため、`start()` -> `pause()` の処理の流れを 
   `initialize()` -> `advanceUntil()` へ変更
  - runner.spec で `jest.useFakeTimers()` を使用するよう修正。

