### PR TITLE
Fix runner-v3's NodeScriptAsset and NodeTextAsset to allow empty string

### DIFF
--- a/packages/headless-driver-runner-v3/src/platform/assets/NodeScriptAsset.ts
+++ b/packages/headless-driver-runner-v3/src/platform/assets/NodeScriptAsset.ts
@@ -31,7 +31,7 @@ export class NodeScriptAsset extends Asset implements g.ScriptAsset {
 					message: err.message,
 					retriable: false
 				});
-			} else if (!text) {
+			} else if (text == null) {
 				loader._onAssetError(this, {
 					name: "AssetLoadError",
 					message: "NoteScriptAsset#_load(): No data received",

--- a/packages/headless-driver-runner-v3/src/platform/assets/NodeTextAsset.ts
+++ b/packages/headless-driver-runner-v3/src/platform/assets/NodeTextAsset.ts
@@ -25,7 +25,7 @@ export class NodeTextAsset extends Asset implements g.TextAsset {
 					message: err.message,
 					retriable: false
 				});
-			} else if (!text) {
+			} else if (text == null) {
 				loader._onAssetError(this, {
 					name: "AssetLoadError",
 					message: "NoteScriptAsset#_load(): No data received",

--- a/packages/headless-driver-runner-v3/src/platform/assets/NodeTextAsset.ts
+++ b/packages/headless-driver-runner-v3/src/platform/assets/NodeTextAsset.ts
@@ -28,7 +28,7 @@ export class NodeTextAsset extends Asset implements g.TextAsset {
 			} else if (text == null) {
 				loader._onAssetError(this, {
 					name: "AssetLoadError",
-					message: "NoteScriptAsset#_load(): No data received",
+					message: "NodeTextAsset#_load(): No data received",
 					retriable: false
 				});
 			} else {


### PR DESCRIPTION
## 概要

headless-driver-runner-v3 の  `NoteScriptAsset`,  `NodeTextAsset` で空文字を許容するようにします。
`if (!text){...` で空文字もはじかれてエラーとなるため、`text == null` に修正し空文字を許容します。  
