### PR TITLE
fix: export `g` namespaces

### DIFF
--- a/packages/headless-driver-runner-v1/src/RunnerV1.ts
+++ b/packages/headless-driver-runner-v1/src/RunnerV1.ts
@@ -2,14 +2,11 @@ import { akashicEngine as g, gameDriver as gdr, pdi } from "@akashic/engine-file
 import { Runner, RunnerPointEvent, RunnerStartParameters } from "@akashic/headless-driver-runner";
 import { PlatformV1 } from "./platform/PlatformV1";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type RunnerV1_g = typeof g;
-
 export type RunnerV1Game = g.Game;
 
 export class RunnerV1 extends Runner {
 	readonly engineVersion: string = "1";
-	readonly g: RunnerV1_g = g;
+	readonly g: typeof g = g;
 	platform: PlatformV1 | null = null;
 
 	private driver: gdr.GameDriver | null = null;

--- a/packages/headless-driver-runner-v1/src/index.ts
+++ b/packages/headless-driver-runner-v1/src/index.ts
@@ -1,2 +1,5 @@
 export * from "./RunnerV1";
 export * from "./platform/PlatformV1";
+export { akashicEngine as RunnerV1_g } from "@akashic/engine-files";
+export { gameDriver as RunnerV1_gdr } from "@akashic/engine-files";
+export { pdi as RunnerV1_pdi } from "@akashic/engine-files";

--- a/packages/headless-driver-runner-v2/src/RunnerV2.ts
+++ b/packages/headless-driver-runner-v2/src/RunnerV2.ts
@@ -2,14 +2,11 @@ import { akashicEngine as g, gameDriver as gdr, pdi } from "@akashic/engine-file
 import { Runner, RunnerPointEvent, RunnerStartParameters } from "@akashic/headless-driver-runner";
 import { PlatformV2 } from "./platform/PlatformV2";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type RunnerV2_g = typeof g;
-
 export type RunnerV2Game = g.Game;
 
 export class RunnerV2 extends Runner {
 	readonly engineVersion: string = "2";
-	readonly g: RunnerV2_g = g;
+	readonly g: typeof g = g;
 	platform: PlatformV2 | null = null;
 
 	private driver: gdr.GameDriver | null = null;

--- a/packages/headless-driver-runner-v2/src/index.ts
+++ b/packages/headless-driver-runner-v2/src/index.ts
@@ -1,2 +1,5 @@
 export * from "./RunnerV2";
 export * from "./platform/PlatformV2";
+export { akashicEngine as RunnerV2_g } from "@akashic/engine-files";
+export { gameDriver as RunnerV2_gdr } from "@akashic/engine-files";
+export { pdi as RunnerV2_pdi } from "@akashic/engine-files";

--- a/packages/headless-driver-runner-v3/src/RunnerV3.ts
+++ b/packages/headless-driver-runner-v3/src/RunnerV3.ts
@@ -5,14 +5,11 @@ import type { NodeCanvasSurface } from "./platform/graphics/canvas/NodeCanvasSur
 import type { NullSurface } from "./platform/graphics/null/NullSurface";
 import { PlatformV3 } from "./platform/PlatformV3";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type RunnerV3_g = typeof g;
-
 export type RunnerV3Game = g.Game;
 
 export class RunnerV3 extends Runner {
 	readonly engineVersion: string = "3";
-	readonly g: RunnerV3_g = g;
+	readonly g: typeof g = g;
 	platform: PlatformV3 | null = null;
 
 	private driver: gdr.GameDriver | null = null;

--- a/packages/headless-driver-runner-v3/src/index.ts
+++ b/packages/headless-driver-runner-v3/src/index.ts
@@ -1,2 +1,5 @@
 export * from "./RunnerV3";
 export * from "./platform/PlatformV3";
+export { akashicEngine as RunnerV3_g } from "./engineFiles";
+export { gameDriver as RunnerV3_gdr } from "./engineFiles";
+export { pdi as RunnerV3_pdi } from "./engineFiles";

--- a/packages/headless-driver/src/__tests__/runner.spec.ts
+++ b/packages/headless-driver/src/__tests__/runner.spec.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
-import { RunnerV1, RunnerV1Game } from "@akashic/headless-driver-runner-v1";
-import { RunnerV2, RunnerV2Game } from "@akashic/headless-driver-runner-v2";
-import { RunnerV3, RunnerV3Game } from "@akashic/headless-driver-runner-v3";
+import { RunnerV1, RunnerV1Game, RunnerV1_g } from "@akashic/headless-driver-runner-v1";
+import { RunnerV2, RunnerV2Game, RunnerV2_g } from "@akashic/headless-driver-runner-v2";
+import { RunnerV3, RunnerV3Game, RunnerV3_g } from "@akashic/headless-driver-runner-v3";
 import * as ExecuteVmScriptV1 from "../ExecuteVmScriptV1";
 import * as ExecuteVmScriptV2 from "../ExecuteVmScriptV2";
 import * as ExecuteVmScriptV3 from "../ExecuteVmScriptV3";
@@ -54,6 +54,10 @@ async function readyRunner(gameJsonPath: string): Promise<(RunnerV1 | RunnerV2 |
 }
 
 describe("Runner の動作確認 (v1)", () => {
+	it("RunnerV3_g が参照できることを確認", () => {
+		expect(RunnerV1_g.Util.charCodeAt("a", 0)).toBe(97);
+	});
+
 	it("Runner#pause() / resume() でコンテンツが一時停止・再開できる", async () => {
 		const runner = (await readyRunner(gameJsonUrlV1)) as RunnerV1;
 
@@ -141,6 +145,10 @@ describe("Runner の動作確認 (v1)", () => {
 });
 
 describe("Runner の動作確認 (v2)", () => {
+	it("RunnerV2_g が参照できることを確認", () => {
+		expect(RunnerV2_g.Util.charCodeAt("a", 0)).toBe(97);
+	});
+
 	it("Runner#pause() / resume() でコンテンツが一時停止・再開できる", async () => {
 		const runner = (await readyRunner(gameJsonUrlV2)) as RunnerV2;
 
@@ -236,6 +244,10 @@ describe("Runner の動作確認 (v2)", () => {
 });
 
 describe("Runner の動作確認 (v3)", () => {
+	it("RunnerV3_g が参照できることを確認", () => {
+		expect(RunnerV3_g.Util.charCodeAt("a", 0)).toBe(97);
+	});
+
 	it("Runner#pause() / resume() でコンテンツが一時停止・再開できる", async () => {
 		const runner = (await readyRunner(gameJsonUrlV3)) as RunnerV3;
 

--- a/packages/headless-driver/src/__tests__/runner.spec.ts
+++ b/packages/headless-driver/src/__tests__/runner.spec.ts
@@ -54,7 +54,7 @@ async function readyRunner(gameJsonPath: string): Promise<(RunnerV1 | RunnerV2 |
 }
 
 describe("Runner の動作確認 (v1)", () => {
-	it("RunnerV3_g が参照できることを確認", () => {
+	it("RunnerV1_g が参照できることを確認", () => {
 		expect(RunnerV1_g.Util.charCodeAt("a", 0)).toBe(97);
 	});
 


### PR DESCRIPTION
# このPullRequestが解決する内容
`RunnerV3_g` の型が `typeof g` となっていたのを `@akashic/engine-files` から直接 export するように修正します。
https://github.com/akashic-contents/templates/pull/5#discussion_r742568158 の件の対応となります。