### PR TITLE
ignore v1 v2 renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,8 @@
           "packages/headless-driver-runner-v1/**",
           "packages/headless-driver-runner-v2/**"
       ],
-      "ignoreDeps": ["@akashic/engine-files"]
+      "ignoreDeps": ["@akashic/engine-files"],
+      "groupName": "headless-driver-runner v1 v2"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -40,10 +40,13 @@
       "matchUpdateTypes": ["minor"],
       "excludePackagePatterns": ["@akashic/", "eslint", "jest"],
       "groupName": "minor dependencies"
+    },
+    {
+      "matchPaths": [
+          "packages/headless-driver-runner-v1/**",
+          "packages/headless-driver-runner-v2/**"
+      ],
+      "ignoreDeps": ["@akashic/engine-files"]
     }
-  ],
-  "ignorePaths": [
-    "packages/headless-driver-runner-v1/node_modules/@akashic/engine-files/**",
-    "packages/headless-driver-runner-v2/node_modules/@akashic/engine-files/**"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -41,5 +41,9 @@
       "excludePackagePatterns": ["@akashic/", "eslint", "jest"],
       "groupName": "minor dependencies"
     }
+  ],
+  "ignorePaths": [
+    "packages/headless-driver-runner-v1/**",
+    "packages/headless-driver-runner-v2/**"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
     }
   ],
   "ignorePaths": [
-    "packages/headless-driver-runner-v1/**",
-    "packages/headless-driver-runner-v2/**"
+    "packages/headless-driver-runner-v1/node_modules/@akashic/engine-files/**",
+    "packages/headless-driver-runner-v2/node_modules/@akashic/engine-files/**"
   ]
 }


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

renovateのチェックがv1/v2系にもなされるため、意図しない依存更新PRが生成されてしまうことがあります。
`ignorePath` を指定することでこれを防ぎます。

## 破壊的な変更を含んでいるか?

- なし

