### PR TITLE
prepare v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.0
+* リポジトリのモノレポを廃止
+  * それに伴い `@akashic/headless-driver-runner-v*` 及び `@akashic/headless-driver-runner` は 2.0.0 以降新たなバージョンはリリースされなくなります。
+
 ## v1.11.36 (2022-03-03)
 
 #### Update Dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",
@@ -18,7 +18,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta",
     "@akashic:registry": "https://registry.npmjs.org/"
   },
   "files": [


### PR DESCRIPTION
# このPullRequestが解決する内容
`headless-driver@2.0.0` のリリース準備です。

## 動作確認項目
* akashic-cli-serve にて v1, v2, v3 コンテンツの実行まで確認
* headless-akashic にて結合テストが動作することを確認 (一部型の修正あり)