### PR TITLE
prevent aev1/aev2 update from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
     "before 6am every weekday"
   ],
   "automerge": true,
+  "ignoreDeps": ["aev1", "aev2"],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@akashic/"],
@@ -40,12 +41,6 @@
       "matchUpdateTypes": ["minor"],
       "excludePackagePatterns": ["@akashic/", "eslint", "jest"],
       "groupName": "minor dependencies"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "matchPackageNames": ["aev1", "aev2"],
-      "enabled": false,
-      "groupName": "engine-files v1 v2"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,6 @@
     "before 6am every weekday"
   ],
   "automerge": true,
-  "ignoreDeps": ["aev1", "aev2"],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@akashic/"],
@@ -41,6 +40,12 @@
       "matchUpdateTypes": ["minor"],
       "excludePackagePatterns": ["@akashic/", "eslint", "jest"],
       "groupName": "minor dependencies"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "matchPackageNames": ["aev1", "aev2"],
+      "enabled": false,
+      "groupName": "engine-files v1 v2"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,19 @@
     "before 6am every weekday"
   ],
   "automerge": true,
-  "ignoreDeps": ["aev1", "aev2"],
   "packageRules": [
+    {
+      "matchPackageNames": ["aev1"],
+      "allowedVersions": "<2.0"
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "allowedVersions": "<3.0"
+    },
+    {
+      "matchPackageNames": ["aev3"],
+      "allowedVersions": "<4.0"
+    },
     {
       "matchPackagePatterns": ["^@akashic/"],
       "schedule": "at any time",

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
     "before 6am every weekday"
   ],
   "automerge": true,
+  "ignoreDeps": ["aev1", "aev2"],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@akashic/"],


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

renovateがengine-filesのv1/v2系を更新しないようにします。

動作確認は https://github.com/kamakiri01/headless-driver/ で行いました。
この修正でDashboard https://github.com/kamakiri01/headless-driver/issues/1 のedit logから、engine-filesのPRが取り下げられたことが確認できます。

## 破壊的な変更を含んでいるか?

- なし

