### PR TITLE
Bump version 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.1.1
+* @akashic/engine-files@3.2.2 に更新
+
 ## 2.1.0
 * @akashic/engine-files@3.2.0 に更新
 * @akashic/engine-files@2.2.0 に更新

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",


### PR DESCRIPTION
## 概要

engine-files@3.2.2 に更新のため、version を 2.1.1 へあげます。
セルフマージとします。