### PR TITLE
chore: bumpVersion を有効に

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: npm
       - name: Prepare
         run: |
-          npm install
+          npm ci
           npm test
       - name: Publish and Release
         uses: akashic-games/action-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [12.x, 14.x]
+        node: [14.x, 16.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -21,5 +21,5 @@ jobs:
           cache: npm
       - name: Run test
         run: |
-          npm install
+          npm ci
           npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://github.com/akashic-games/headless-driver/blob/master/img/akashic.png"/>
+<img src="https://raw.githubusercontent.com/akashic-games/headless-driver/main/img/akashic.png"/>
 </p>
 
 # headless-driver
@@ -26,6 +26,6 @@ npm run build
 ## ライセンス
 本リポジトリは MIT License の元で公開されています。
 詳しくは [LICENSE](https://github.com/akashic-games/headless-driver/blob/master/LICENSE) をご覧ください。
- 
+
 ただし、画像ファイルおよび音声ファイルは
 [CC BY 2.1 JP](https://creativecommons.org/licenses/by/2.1/jp/) の元で公開されています。

--- a/renovate.json
+++ b/renovate.json
@@ -1,39 +1,55 @@
 {
   "extends": [
-    "config:base",
-    ":timezone(Asia/Tokyo)",
-    ":prConcurrentLimitNone",
-    ":prHourlyLimitNone",
-    ":dependencyDashboard",
-    ":preserveSemverRanges",
-    ":label(dependencies)",
-    ":separatePatchReleases",
-    "group:definitelyTyped"
-  ],
-  "schedule": [
-    "every weekend",
-    "after 10pm every weekday",
-    "before 6am every weekday"
+    "github>akashic-games/renovate-config",
+    "github>akashic-games/renovate-config:groupPatchMinor",
+    "github>akashic-games/renovate-config:bumpAkashicPatch"
   ],
   "automerge": true,
   "packageRules": [
     {
       "matchPackageNames": ["aev1"],
-      "allowedVersions": "<2.0"
+      "allowedVersions": "<2.0",
+      "schedule": "at any time"
+    },
+    {
+      "matchPackageNames": ["aev1"],
+      "matchUpdateTypes": ["patch"],
+      "bumpVersion": "patch"
+    },
+    {
+      "matchPackageNames": ["aev1"],
+      "matchUpdateTypes": ["minor"],
+      "bumpVersion": "minor"
     },
     {
       "matchPackageNames": ["aev2"],
-      "allowedVersions": "<3.0"
+      "allowedVersions": "<3.0",
+      "schedule": "at any time"
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "matchUpdateTypes": ["patch"],
+      "bumpVersion": "patch"
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "matchUpdateTypes": ["minor"],
+      "bumpVersion": "minor"
     },
     {
       "matchPackageNames": ["aev3"],
-      "allowedVersions": "<4.0"
+      "allowedVersions": "<4.0",
+      "schedule": "at any time"
     },
     {
-      "matchPackagePatterns": ["^@akashic/"],
-      "schedule": "at any time",
-      "groupName": "akashic packages",
-      "automerge": false
+      "matchPackageNames": ["aev3"],
+      "matchUpdateTypes": ["patch"],
+      "bumpVersion": "patch"
+    },
+    {
+      "matchPackageNames": ["aev3"],
+      "matchUpdateTypes": ["minor"],
+      "bumpVersion": "minor"
     },
     {
       "matchPackagePatterns": ["eslint"],


### PR DESCRIPTION
# このPullRequestが解決する内容
* `aev*` を自動更新するように修正します
* CI のテスト環境を Node 14, 16 に更新します