### PR TITLE
fix: avoid errors on getTickList() for no tick range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.5.3
+* ティックがない状態で AMFlowClient#getTickList() が誤ってエラーになる問題を修正
+
 ## 2.5.2
 * 内部モジュールの更新
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/src/play/amflow/AMFlowClient.ts
+++ b/src/play/amflow/AMFlowClient.ts
@@ -224,11 +224,7 @@ export class AMFlowClient implements AMFlow {
 				return;
 			}
 			const tickList = this.store.getTickList(opts);
-			if (tickList) {
-				callback(null, tickList);
-			} else {
-				callback(createError("runtime_error", "No tick list"), undefined);
-			}
+			callback(null, tickList ?? undefined);
 		});
 	}
 

--- a/src/play/amflow/AMFlowStore.ts
+++ b/src/play/amflow/AMFlowStore.ts
@@ -62,6 +62,9 @@ export class AMFlowStore {
 		const tickList = opts.excludeEventFlags && opts.excludeEventFlags.ignorable ? this.filteredTickList : this.unfilteredTickList;
 		const from = Math.max(opts.begin, tickList[TickListIndex.From]);
 		const to = Math.min(opts.end - 1, tickList[TickListIndex.To]);
+		if (to < from) {
+			return null;
+		}
 
 		const tickListTicks = tickList[TickListIndex.Ticks];
 		if (tickListTicks == null) {


### PR DESCRIPTION
掲題どおり。以下を修正します。

- ティックが全くない状態で `getTickList()` するとエラーになる
- 何らかのティックがある状態で、それを全く含まない範囲 (e.g. 未来すぎる) を `getTickList()` すると、得られる `TickList` がおかしい (終了ティックの方が開始ティックより前になるなど)

いずれも期待動作は「TickList として `undefined` が返る」です。当時の設計者の意向により、TickList は [begin, end) ではなく [from, to]  (すなわち終端を含む) になっているため、こうでないと「ティックがない」ことを表現できません。

修正に併せて、対応するユニットテストを追加します。

### 補足: なぜ今か

この問題がこれまで露見しなかったのは、akashic serve (`getTickList()` を使う主要なユーザ) の使い方によるものと想像します。serve は先に runner を生成してからクライアント側のコンテンツを開始するため、時間的に「ティックがない状態で `getTickList()` が呼ばれる」ことが稀だったように思います。
