### PR TITLE
feat: add options for RunnerManager#startRunner()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.6.0
+* `RunnerManager#startRunner()` の引数にオプションを追加。ポーズ状態で開始できるように
+
 ## 2.5.3
 * ティックがない状態で AMFlowClient#getTickList() が誤ってエラーになる問題を修正
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.5.3",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/src/runner/RunnerManager.ts
+++ b/src/runner/RunnerManager.ts
@@ -9,7 +9,7 @@ import { getSystemLogger } from "../Logger";
 import type { AMFlowClient } from "../play/amflow/AMFlowClient";
 import type { PlayManager } from "../play/PlayManager";
 import { loadFile } from "../utils";
-import type { RunnerParameters } from "./Runner";
+import type { RunnerParameters, RunnerStartParameters } from "./Runner";
 import type { RunnerExecutionMode, RunnerPlayer, RunnerRenderingMode } from "./types";
 import type { RunnerV1, RunnerV1Game } from "./v1";
 import type { RunnerV2, RunnerV2Game } from "./v2";
@@ -214,14 +214,14 @@ export class RunnerManager {
 	 * Runner を開始する。
 	 * @param runnerId RunnerID
 	 */
-	async startRunner(runnerId: string): Promise<RunnerV1Game | RunnerV2Game | RunnerV3Game | null> {
+	async startRunner(runnerId: string, options?: RunnerStartParameters): Promise<RunnerV1Game | RunnerV2Game | RunnerV3Game | null> {
 		const runner = this.getRunner(runnerId);
 
 		if (!runner) {
 			throw new Error("Runner is not found");
 		}
 
-		return runner.start();
+		return runner.start(options);
 	}
 
 	/**


### PR DESCRIPTION
掲題どおり。

オプションを追加して `Runner#start()` に引き渡します。

内容はほぼ自明で、`start()` の動作そのものは runner.spec.ts で確認されていること、さらに (このクラスを扱っている) run.spec.ts はこの粒度のテストはしていないことから、テストの追加はしていません。
