### PR TITLE
fix: throttle loadFile() to avoid hung on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.6.3
+* Windows で大量のアセットを使うコンテンツで実行が止まる問題を修正 (ファイル読み込み・ネットワークアクセスの並列実行数を制限するように)
+
 ## 2.6.2
 * canvas を optionalDependencies　から devDependencies へ変更
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,0 +1,70 @@
+import { loadFile, LoadFileInternal } from "../utils";
+
+describe("utils.loadFile()", () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it("ファイルをロードできる", async () => {
+		jest.spyOn(LoadFileInternal, "loadImpl").mockImplementation((url) => Promise.resolve(url));
+		const loaded = await loadFile("test");
+		expect(loaded).toBe("test");
+	});
+
+	it("並列ロード数を制限する", async () => {
+		const resolverTable: { [url: string]: () => void } = {};
+		jest.spyOn(LoadFileInternal, "loadImpl").mockImplementation((url) => {
+			return new Promise((resolve) => {
+				resolverTable[url] = () => {
+					delete resolverTable[url];
+					resolve("content:" + url);
+				};
+			});
+		});
+
+		const promiseTable: { [url: string]: Promise<string> } = {};
+		function load(url: string): void {
+			promiseTable[url] = loadFile(url);
+		}
+
+		for (let i = 0; i < LoadFileInternal.MAX_PARALLEL_LOAD; ++i) {
+			load("test-" + i);
+		}
+		load("delayed-1");
+		load("delayed-2");
+
+		// (MAX_PARALLEL_LOAD + 2) のロードを同期的に実行したが、冒頭 MAX_PARALLEL_LOAD 個しかロード処理が走らない。
+		expect(Object.keys(resolverTable).length).toBe(LoadFileInternal.MAX_PARALLEL_LOAD);
+		expect(resolverTable["test-" + (LoadFileInternal.MAX_PARALLEL_LOAD - 1)]).not.toBe(undefined);
+		expect(resolverTable["delayed-1"]).toBe(undefined);
+		expect(resolverTable["delayed-2"]).toBe(undefined);
+
+		// 一つロードを完了すると次 (delayed-1) のロードが走る。
+		resolverTable["test-2"]();
+		const test2content = await promiseTable["test-2"];
+		expect(test2content).toBe("content:test-2");
+		expect(Object.keys(resolverTable).length).toBe(LoadFileInternal.MAX_PARALLEL_LOAD);
+		expect(resolverTable["delayed-1"]).not.toBe(undefined);
+		expect(resolverTable["delayed-2"]).toBe(undefined);
+
+		// さらにロードを完了すると次 (delayed-2) のロードが走る。
+		resolverTable["test-1"]();
+		await promiseTable["test-1"];
+		expect(Object.keys(resolverTable).length).toBe(LoadFileInternal.MAX_PARALLEL_LOAD);
+		expect(resolverTable["delayed-1"]).not.toBe(undefined);
+		expect(resolverTable["delayed-2"]).not.toBe(undefined);
+
+		// さらにロードを完了すると、その後のロードもただちに走る。
+		resolverTable["test-0"]();
+		await promiseTable["test-0"];
+		expect(Object.keys(resolverTable).length).toBe(LoadFileInternal.MAX_PARALLEL_LOAD - 1);
+		load("delayed-3");
+		expect(Object.keys(resolverTable).length).toBe(LoadFileInternal.MAX_PARALLEL_LOAD);
+		expect(resolverTable["delayed-3"]).not.toBe(undefined);
+
+		// 最終的に全部のロードが完了する。
+		Object.values(resolverTable).forEach(r => r());
+		const contents = await Promise.all(Object.values(promiseTable));
+		expect(contents.length).toBe(LoadFileInternal.MAX_PARALLEL_LOAD + 3); // test-0〜(MAX_PARALLEL_LOAD-1) と delayed-1〜3
+	});
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ async function processWaitingLoad(): Promise<void> {
 export namespace LoadFileInternal {
 	/**
 	 * 最大並列ロード数。
-	 * 環境によって、一定数以上の fetch() を並列に実行すると応答がなくなったりエラーになる場合がある。
+	 * 環境によって、node-fetch を一定数以上並列に実行すると応答がなくなったりエラーになる場合がある。
 	 * 具体的な値は調整の余地がある。少なくとも Windows 環境で、128 以上で問題が起きることがわかっている。
 	 */
 	export const MAX_PARALLEL_LOAD = 32;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,62 @@
 import * as fs from "fs";
 import fetch from "node-fetch";
 
+interface WaitingInfo {
+	url: string;
+	resolve: (s: string) => void;
+	reject: (e: any) => void;
+}
+
+const waitings: WaitingInfo[] = [];
+let loadingCount: number = 0;
+
 /**
  * ファイルを読み込む。
  *
  * @param url url または path
- * @param opt オプション
  */
 export async function loadFile(url: string): Promise<string> {
-	if (isHttpProtocol(url)) {
-		const res = await fetch(url, { method: "GET" });
-		return res.text();
-	} else {
-		const str = fs.readFileSync(url, { encoding: "utf8" });
-		return str;
+	const promise = new Promise<string>((resolve, reject) => {
+		waitings.push({ url, resolve, reject });
+	});
+	processWaitingLoad();
+	return promise;
+}
+
+async function processWaitingLoad(): Promise<void> {
+	if (loadingCount >= LoadFileInternal.MAX_PARALLEL_LOAD || waitings.length === 0) return;
+	const { url, resolve, reject } = waitings.shift()!;
+	try {
+		++loadingCount;
+		resolve(await LoadFileInternal.loadImpl(url));
+	} catch (e) {
+		reject(e);
+	} finally {
+		--loadingCount;
+		processWaitingLoad();
+	}
+}
+
+/**
+ * loadFile() の内部実装のうち、特にテストのため外部から参照するものをまとめた namespace 。
+ * 通常の利用では参照する必要はない。
+ */
+export namespace LoadFileInternal {
+	/**
+	 * 最大並列ロード数。
+	 * 環境によって、一定数以上の fetch() を並列に実行すると応答がなくなったりエラーになる場合がある。
+	 * 具体的な値は調整の余地がある。少なくとも Windows 環境で、128 以上で問題が起きることがわかっている。
+	 */
+	export const MAX_PARALLEL_LOAD = 32;
+
+	export async function loadImpl(url: string): Promise<string> {
+		if (isHttpProtocol(url)) {
+			const res = await fetch(url, { method: "GET" });
+			return res.text();
+		} else {
+			const str = fs.readFileSync(url, { encoding: "utf8" });
+			return str;
+		}
 	}
 }
 


### PR DESCRIPTION
掲題どおり。

Windows 環境の akashic serve で、グローバルアセットが 130 程度あるコンテンツを実行した時、 `loadFile()` が失敗してコンテンツを開始できない問題が報告されました。(確認した Windows 11 環境ではロード完了が来ません。また報告では Windows 10 でエラーが返されるとのこと)　この状況では 130 回程度の fetch() が同期的に呼び出されます。

問題を回避するため、キューを設けて同時に実行するロード数を制限します。

akashic serve に組み込み、Windows 11 環境で問題を再現するコンテンツが正しく実行できるようになることを確認しています。
