### PR TITLE
load assets asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased changes
+* `NullAudioAsset`, `NullImageAsset`, `NullVideoAsset` を非同期でロードするように
+
 ## 2.8.0
 * 内部モジュールの更新
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased changes
+## 2.8.1
 * `NullAudioAsset`, `NullImageAsset`, `NullVideoAsset` を非同期でロードするように
 
 ## 2.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/src/runner/v1/platform/assets/NullAudioAsset.ts
+++ b/src/runner/v1/platform/assets/NullAudioAsset.ts
@@ -2,7 +2,6 @@ import { akashicEngine as g } from "engine-files-v1";
 
 export class NullAudioAsset extends g.AudioAsset {
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v1/platform/assets/NullAudioAsset.ts
+++ b/src/runner/v1/platform/assets/NullAudioAsset.ts
@@ -2,6 +2,9 @@ import { akashicEngine as g } from "engine-files-v1";
 
 export class NullAudioAsset extends g.AudioAsset {
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 }

--- a/src/runner/v1/platform/assets/NullImageAsset.ts
+++ b/src/runner/v1/platform/assets/NullImageAsset.ts
@@ -5,7 +5,6 @@ export class NullImageAsset extends g.ImageAsset {
 	_surface: g.Surface | null = null;
 
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v1/platform/assets/NullImageAsset.ts
+++ b/src/runner/v1/platform/assets/NullImageAsset.ts
@@ -5,7 +5,10 @@ export class NullImageAsset extends g.ImageAsset {
 	_surface: g.Surface | null = null;
 
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v1/platform/assets/NullVideoAsset.ts
+++ b/src/runner/v1/platform/assets/NullVideoAsset.ts
@@ -11,7 +11,6 @@ export class NullVideoAsset extends g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v1/platform/assets/NullVideoAsset.ts
+++ b/src/runner/v1/platform/assets/NullVideoAsset.ts
@@ -11,7 +11,10 @@ export class NullVideoAsset extends g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v2/platform/assets/NullAudioAsset.ts
+++ b/src/runner/v2/platform/assets/NullAudioAsset.ts
@@ -2,7 +2,6 @@ import { akashicEngine as g } from "engine-files-v2";
 
 export class NullAudioAsset extends g.AudioAsset {
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v2/platform/assets/NullAudioAsset.ts
+++ b/src/runner/v2/platform/assets/NullAudioAsset.ts
@@ -2,6 +2,9 @@ import { akashicEngine as g } from "engine-files-v2";
 
 export class NullAudioAsset extends g.AudioAsset {
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 }

--- a/src/runner/v2/platform/assets/NullImageAsset.ts
+++ b/src/runner/v2/platform/assets/NullImageAsset.ts
@@ -5,7 +5,6 @@ export class NullImageAsset extends g.ImageAsset {
 	_surface: g.Surface | null = null;
 
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v2/platform/assets/NullImageAsset.ts
+++ b/src/runner/v2/platform/assets/NullImageAsset.ts
@@ -5,7 +5,10 @@ export class NullImageAsset extends g.ImageAsset {
 	_surface: g.Surface | null = null;
 
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v2/platform/assets/NullVideoAsset.ts
+++ b/src/runner/v2/platform/assets/NullVideoAsset.ts
@@ -11,7 +11,6 @@ export class NullVideoAsset extends g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v2/platform/assets/NullVideoAsset.ts
+++ b/src/runner/v2/platform/assets/NullVideoAsset.ts
@@ -11,7 +11,10 @@ export class NullVideoAsset extends g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v3/platform/audios/NullAudioAsset.ts
+++ b/src/runner/v3/platform/audios/NullAudioAsset.ts
@@ -29,7 +29,6 @@ export class NullAudioAsset extends Asset implements g.AudioAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v3/platform/audios/NullAudioAsset.ts
+++ b/src/runner/v3/platform/audios/NullAudioAsset.ts
@@ -29,7 +29,10 @@ export class NullAudioAsset extends Asset implements g.AudioAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 
 	play(): g.AudioPlayer {

--- a/src/runner/v3/platform/graphics/null/NullImageAsset.ts
+++ b/src/runner/v3/platform/graphics/null/NullImageAsset.ts
@@ -17,7 +17,10 @@ export class NullImageAsset extends Asset implements g.ImageAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v3/platform/graphics/null/NullImageAsset.ts
+++ b/src/runner/v3/platform/graphics/null/NullImageAsset.ts
@@ -17,7 +17,6 @@ export class NullImageAsset extends Asset implements g.ImageAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v3/platform/videos/NullVideoAsset.ts
+++ b/src/runner/v3/platform/videos/NullVideoAsset.ts
@@ -29,7 +29,6 @@ export class NullVideoAsset extends Asset implements g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
 		setTimeout(() => {
 			loader._onAssetLoad(this);
 		}, 0);

--- a/src/runner/v3/platform/videos/NullVideoAsset.ts
+++ b/src/runner/v3/platform/videos/NullVideoAsset.ts
@@ -29,7 +29,10 @@ export class NullVideoAsset extends Asset implements g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		loader._onAssetLoad(this);
+		// アセットのロードは原則非同期としたいのでsetTimeoutを使用
+		setTimeout(() => {
+			loader._onAssetLoad(this);
+		}, 0);
 	}
 
 	asSurface(): g.Surface {


### PR DESCRIPTION
### 概要
* serveのサーバー(headless-driver)側の画像や音声のアセットのロード処理が同期的だったので、サーバー側もクライアント側と同様にアセットのロードは原則非同期的にするように変更