### PR TITLE
Add ignore to import part of canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 2.8.2
-* headless-driver の利用側で Canvas の参照エラーとなる箇所に `@ts-ignore` を追加
+* TypeScript での利用時に `node-canvas` がインストールされていなくてもコンパイルできるように
 
 ## 2.8.1
 * `NullAudioAsset`, `NullImageAsset`, `NullVideoAsset` を非同期でロードするように

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.8.2
+* headless-driver の利用側で Canvas の型エラーとなる箇所に `@ts-ignore` を追加
+
 ## 2.8.1
 * `NullAudioAsset`, `NullImageAsset`, `NullVideoAsset` を非同期でロードするように
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 2.8.2
-* headless-driver の利用側で Canvas の型エラーとなる箇所に `@ts-ignore` を追加
+* headless-driver の利用側で Canvas の参照エラーとなる箇所に `@ts-ignore` を追加
 
 ## 2.8.1
 * `NullAudioAsset`, `NullImageAsset`, `NullVideoAsset` を非同期でロードするように

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/src/runner/v3/RunnerV3.ts
+++ b/src/runner/v3/RunnerV3.ts
@@ -1,3 +1,4 @@
+/** @ts-ignore */
 import type { Canvas } from "canvas";
 import type { RunnerStartParameters } from "../Runner";
 import { Runner } from "../Runner";

--- a/src/runner/v3/platform/graphics/canvas/NodeCanvasRenderer.ts
+++ b/src/runner/v3/platform/graphics/canvas/NodeCanvasRenderer.ts
@@ -1,3 +1,4 @@
+/** @ts-ignore */
 import type { CanvasRenderingContext2D, ImageData } from "canvas";
 import type { akashicEngine as g } from "../../../engineFiles";
 import { CompositeOperationConverter } from "./CompositeOperationConverter";

--- a/src/runner/v3/platform/graphics/canvas/NodeCanvasSurface.ts
+++ b/src/runner/v3/platform/graphics/canvas/NodeCanvasSurface.ts
@@ -1,3 +1,4 @@
+/** @ts-ignore */
 import type { Canvas } from "canvas";
 import type { akashicEngine as g } from "../../../engineFiles";
 import { NodeCanvasRenderer } from "./NodeCanvasRenderer";


### PR DESCRIPTION
## 概要

headless-driver の利用側で canvas の参照エラーとなる import 箇所に `@ts-ignore` を追加。

**動作確認**
npm pack した tgz ファイルを serve で取り込み、tsconfig の skipLibCheck オプションを外してビルドが正常終了することを確認。