### PR TITLE
Support node v18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: npm
       - name: Prepare
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [14.x, 16.x]
+        node: [16.x, 18.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -36,7 +36,7 @@ declare global {
 
 export const initialize = async (): Promise<void> => {
 	const port = await getPort();
-	const host = "::0";
+	const host = "::0"; // Node v17 から ipv6 がデフォルトとなったため ipv6 を利用
 	const baseUrl = `http://[${host}]:${port}`;
 	const extPort = port;
 	const extHost = "::ffff:7f00:1";

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -36,11 +36,11 @@ declare global {
 
 export const initialize = async (): Promise<void> => {
 	const port = await getPort();
-	const host = "localhost";
-	const baseUrl = `http://${host}:${port}`;
+	const host = "::0";
+	const baseUrl = `http://[${host}]:${port}`;
 	const extPort = port;
-	const extHost = "127.0.0.1";
-	const extBaseUrl = `http://${extHost}:${extPort}`;
+	const extHost = "::ffff:7f00:1";
+	const extBaseUrl = `http://[${extHost}]:${extPort}`;
 
 	const server = http.createServer((request, response) => {
 		handler(request, response, {


### PR DESCRIPTION
## 概要 

CI の node バージョンを v16, v18 へ更新します。

Node V17からipv6をデフォルトとなったため、`localhost` は `::1` という ipv6アドレスに解決されるためテストでエラーとなった。テストで利用するサーバで ipv6 を利用し ipv6 全てで listen するように修正。

node v18.16.0, v16.19.0 で動作確認。