### PR TITLE
fix: modify to pass the 'exports' to the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.9.1
+* `NodeScriptAsset` のコンストラクタに `exports` が渡されていなかった問題を修正
+
 ## 2.9.0
 * pdi-types@1.11.1 に追従
   * `BinaryAsset` に対応

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/src/__tests__/fixtures/content-v3/assets/exports.js
+++ b/src/__tests__/fixtures/content-v3/assets/exports.js
@@ -1,0 +1,1 @@
+let localVariable = 43;

--- a/src/__tests__/fixtures/content-v3/game.json
+++ b/src/__tests__/fixtures/content-v3/game.json
@@ -12,6 +12,11 @@
 		"akashic": {
 			"type": "binary",
 			"path": "assets/akashic.bin"
+		},
+		"exports": {
+			"type": "script",
+			"path": "assets/exports.js",
+			"exports": ["localVariable"]
 		}
 	},
 	"environment": {

--- a/src/__tests__/fixtures/content-v3/script/main.js
+++ b/src/__tests__/fixtures/content-v3/script/main.js
@@ -83,6 +83,10 @@ function main(param) {
 				}
 			});
 			return;
+		} else if (message.data.type === "load_script_asset_exports") {
+			const { localVariable } = require("../assets/exports");
+			game.external.send(localVariable);
+			return;
 		} else if (message.data.type === "load_binary_asset_data") {
 			// TODO: 他の種別のアセットのテストも追加すべきかもしれない
 			const asset = scene.asset.getBinary("/assets/akashic.bin");

--- a/src/__tests__/run.spec.ts
+++ b/src/__tests__/run.spec.ts
@@ -343,6 +343,16 @@ describe("untrusted コンテンツの動作テスト (URL)", () => {
 		expect(event.data).toEqual({ hoge: "fuga" });
 		expect(event.player.id).toBe(":akashic");
 
+		// コンテンツ側で ScriptAsset#exports が機能しているかを確認
+		activeAMFlow.sendEvent([0x20, 0, ":akashic", { type: "load_script_asset_exports" }]);
+		expect(
+			await new Promise<number>((resolve, _reject) => {
+				runner.sendToExternalTrigger.addOnce((l: number) => {
+					resolve(l);
+				});
+			})
+		).toBe(43);
+
 		// コンテンツ側でバイナリアセットが読み込めているかを確認
 		activeAMFlow.sendEvent([0x20, 0, ":akashic", { type: "load_binary_asset_data" }]);
 		expect(

--- a/src/runner/v3/platform/NodeCanvasResourceFactory.ts
+++ b/src/runner/v3/platform/NodeCanvasResourceFactory.ts
@@ -69,10 +69,11 @@ export class NodeCanvasResourceFactory implements g.ResourceFactory {
 		});
 	}
 
-	createScriptAsset(id: string, assetPath: string): g.ScriptAsset {
+	createScriptAsset(id: string, assetPath: string, exports?: string[]): g.ScriptAsset {
 		return new NodeScriptAsset({
 			id,
 			path: assetPath,
+			exports,
 			errorHandler: this.errorHandler,
 			loadFileHandler: this.loadFileHandler
 		});

--- a/src/runner/v3/platform/NullResourceFactory.ts
+++ b/src/runner/v3/platform/NullResourceFactory.ts
@@ -67,10 +67,11 @@ export class NullResourceFactory implements g.ResourceFactory {
 		});
 	}
 
-	createScriptAsset(id: string, assetPath: string): g.ScriptAsset {
+	createScriptAsset(id: string, assetPath: string, exports?: string[]): g.ScriptAsset {
 		return new NodeScriptAsset({
 			id,
 			path: assetPath,
+			exports,
 			errorHandler: this.errorHandler,
 			loadFileHandler: this.loadFileHandler
 		});


### PR DESCRIPTION
# このPullRequestが解決する内容
`ScriptAsset` のコンストラクタに `exports` を渡すのを忘れていたため修正します。また今回の修正箇所のテストを追加します。