### PR TITLE
fix: fix the bug that the object breaks when rendered at scale 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## unreleased changes
+## 2.13.4
 * `renderingMode` を `"canvas"` にした際に `scaleX` または `scaleY` が 0 のエンティティを描画すると、それ以降描画が停止してしまうバグを修正
 
 ## 2.13.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## unreleased changes
+* `renderingMode` を `"canvas"` にした際に `scaleX` または `scaleY` が 0 のエンティティを描画すると、それ以降描画が停止してしまうバグを修正
+
 ## 2.13.2
 * 内部モジュールの更新
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/pixelmatch": "^5.2.4",
         "@types/pngjs": "^6.0.1",
         "@typescript-eslint/eslint-plugin": "^6.12.0",
-        "canvas": "^2.10.1",
+        "canvas": "^2.11.2",
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.13.3",
+      "version": "2.13.4",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/pixelmatch": "^5.2.4",
     "@types/pngjs": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
-    "canvas": "^2.10.1",
+    "canvas": "^2.11.2",
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.29.0",

--- a/src/runner/v3/__tests__/NodeCanvasRenderer.spec.ts
+++ b/src/runner/v3/__tests__/NodeCanvasRenderer.spec.ts
@@ -172,4 +172,40 @@ describe("NodeCanvasRenderer", () => {
 		fs.writeFileSync(path.join(outputPath, "rendering_test_02_composite_expected.png"), outputCanvas.toBuffer());
 		fs.writeFileSync(path.join(outputPath, "rendering_test_02_composite_actual.png"), outputSurface._drawable.toBuffer());
 	});
+
+	it("rendering - does not break even when rendered at scale 0", async () => {
+		const surface = new NodeCanvasSurface(new Canvas(800, 800));
+		const renderer = surface.renderer();
+
+		renderer.begin();
+
+		{
+			renderer.save();
+			renderer.transform([2, 0, 0, 2, 0, 0]);
+			renderer.transform([1, 0, 0, 0, 0, 0]);
+			renderer.fillRect(100, 100, 100, 100, "red");
+			renderer.restore();
+		}
+
+		{
+			renderer.save();
+			const asset = await createImageAsset(aksImagePath);
+			renderer.setTransform([0, 0, 0, 1, 0, 0]);
+			renderer.drawImage(asset.asSurface(), 20, 20, 80, 80, 10, 300);
+			renderer.restore();
+		}
+
+		{
+			renderer.save();
+			const asset = await createImageAsset(aksImagePath);
+			renderer.transform([3, 0, 0, 3, 0, 0]);
+			// この画像のみ描画される
+			renderer.drawImage(asset.asSurface(), 0, 0, 150, 107, 100, 100);
+			renderer.restore();
+		}
+
+		renderer.end();
+
+		fs.writeFileSync(path.join(outputPath, "rendering_test_03_actual.png"), surface._drawable.toBuffer());
+	});
 });

--- a/src/runner/v3/platform/graphics/canvas/AffineTransformer.ts
+++ b/src/runner/v3/platform/graphics/canvas/AffineTransformer.ts
@@ -1,0 +1,73 @@
+export class AffineTransformer {
+	//
+	//            a b 0
+	// matrix = [ c d 0 ]
+	//            e f 1
+	//
+	// 配列としては [a, b, c, d, e, f] と値を持っている。
+	matrix: Float32Array;
+
+	constructor(rhs?: AffineTransformer) {
+		if (rhs) {
+			this.matrix = new Float32Array(rhs.matrix);
+		} else {
+			this.matrix = new Float32Array([1, 0, 0, 1, 0, 0]);
+		}
+	}
+
+	scale(x: number, y: number): AffineTransformer {
+		const m = this.matrix;
+
+		m[0] *= x;
+		m[1] *= x;
+		m[2] *= y;
+		m[3] *= y;
+
+		return this;
+	}
+
+	translate(x: number, y: number): AffineTransformer {
+		const m = this.matrix;
+
+		m[4] += m[0] * x + m[2] * y;
+		m[5] += m[1] * x + m[3] * y;
+
+		return this;
+	}
+
+	transform(matrix: number[]): AffineTransformer {
+		const m = this.matrix;
+
+		const a = matrix[0] * m[0] + matrix[1] * m[2];
+		const b = matrix[0] * m[1] + matrix[1] * m[3];
+		const c = matrix[2] * m[0] + matrix[3] * m[2];
+		const d = matrix[2] * m[1] + matrix[3] * m[3];
+		const e = matrix[4] * m[0] + matrix[5] * m[2] + m[4];
+		const f = matrix[4] * m[1] + matrix[5] * m[3] + m[5];
+
+		m[0] = a;
+		m[1] = b;
+		m[2] = c;
+		m[3] = d;
+		m[4] = e;
+		m[5] = f;
+
+		return this;
+	}
+
+	setTransform(matrix: number[]): void {
+		const m = this.matrix;
+
+		m[0] = matrix[0];
+		m[1] = matrix[1];
+		m[2] = matrix[2];
+		m[3] = matrix[3];
+		m[4] = matrix[4];
+		m[5] = matrix[5];
+	}
+
+	copyFrom(rhs: AffineTransformer): AffineTransformer {
+		this.matrix.set(rhs.matrix);
+		return this;
+	}
+}

--- a/src/runner/v3/platform/graphics/canvas/NodeCanvasContext.ts
+++ b/src/runner/v3/platform/graphics/canvas/NodeCanvasContext.ts
@@ -1,0 +1,201 @@
+/** @ts-ignore */
+import type { CanvasRenderingContext2D, ImageData, GlobalCompositeOperation } from "canvas";
+import type { akashicEngine as g } from "../../../engineFiles";
+import { RenderingState } from "./RenderingState";
+
+export class NodeCanvasContext {
+	protected _context: CanvasRenderingContext2D;
+	protected _stateStack: RenderingState[] = [];
+
+	protected _contextFillStyle: string;
+	protected _contextGlobalAlpha: number;
+	protected _contextGlobalCompositeOperation: string;
+
+	private _modifiedTransform: boolean = false;
+
+	constructor(context: CanvasRenderingContext2D) {
+		this._context = context;
+		const state = new RenderingState();
+		this._contextFillStyle = state.fillStyle;
+		this._contextGlobalAlpha = state.globalAlpha;
+		this._contextGlobalCompositeOperation = state.globalCompositeOperation;
+		this.pushState(state);
+	}
+
+	set fillStyle(fillStyle: string) {
+		this.currentState().fillStyle = fillStyle;
+	}
+
+	get fillStyle(): string {
+		return this.currentState().fillStyle;
+	}
+
+	set globalAlpha(globalAlpha: number) {
+		this.currentState().globalAlpha = globalAlpha;
+	}
+
+	get globalAlpha(): number {
+		return this.currentState().globalAlpha;
+	}
+
+	set globalCompositeOperation(operation: string) {
+		this.currentState().globalCompositeOperation = operation;
+	}
+
+	get globalCompositeOperation(): string {
+		return this.currentState().globalCompositeOperation;
+	}
+
+	getCanvasRenderingContext2D(): CanvasRenderingContext2D {
+		return this._context;
+	}
+
+	clearRect(x: number, y: number, width: number, height: number): void {
+		this.prerender();
+		this._context.clearRect(x, y, width, height);
+	}
+
+	save(): void {
+		const state = new RenderingState(this.currentState());
+		this.pushState(state);
+	}
+
+	restore(): void {
+		this.popState();
+	}
+
+	scale(x: number, y: number): void {
+		this.currentState().transformer.scale(x, y);
+		this._modifiedTransform = true;
+	}
+
+	drawImage(
+		surface: g.Surface,
+		srcX: number,
+		srcY: number,
+		srcW: number,
+		srcH: number,
+		dstX: number,
+		dstY: number,
+		dstW: number,
+		dstH: number
+	): void {
+		if (this.prerender()) {
+			this._context.drawImage(surface._drawable, srcX, srcY, srcW, srcH, dstX, dstY, dstW, dstH);
+		}
+	}
+
+	fillRect(x: number, y: number, width: number, height: number): void {
+		if (this.prerender()) {
+			this._context.fillRect(x, y, width, height);
+		}
+	}
+
+	fillText(text: string, x: number, y: number, maxWidth: number): void {
+		if (this.prerender()) {
+			this._context.fillText(text, x, y, maxWidth);
+		}
+	}
+
+	strokeText(text: string, x: number, y: number, maxWidth?: number): void {
+		if (this.prerender()) {
+			this._context.strokeText(text, x, y, maxWidth);
+		}
+	}
+
+	translate(x: number, y: number): void {
+		this.currentState().transformer.translate(x, y);
+		this._modifiedTransform = true;
+	}
+
+	transform(m11: number, m12: number, m21: number, m22: number, dx: number, dy: number): void {
+		this.currentState().transformer.transform([m11, m12, m21, m22, dx, dy]);
+		this._modifiedTransform = true;
+	}
+
+	setTransform(m11: number, m12: number, m21: number, m22: number, dx: number, dy: number): void {
+		this.currentState().transformer.setTransform([m11, m12, m21, m22, dx, dy]);
+		this._modifiedTransform = true;
+	}
+
+	setGlobalAlpha(globalAlpha: number): void {
+		this.currentState().globalAlpha = globalAlpha;
+	}
+
+	getImageData(sx: number, sy: number, sw: number, sh: number): ImageData {
+		return this._context.getImageData(sx, sy, sw, sh);
+	}
+
+	putImageData(
+		imagedata: ImageData,
+		dx: number,
+		dy: number,
+		dirtyX?: number,
+		dirtyY?: number,
+		dirtyWidth?: number,
+		dirtyHeight?: number
+	): void {
+		this._context.putImageData(imagedata, dx, dy, dirtyX!, dirtyY!, dirtyWidth!, dirtyHeight!);
+	}
+
+	/**
+	 * 描画の前処理。
+	 * 描画を省略すべきであれば false を返す。
+	 */
+	prerender(): boolean {
+		const currentState = this.currentState();
+
+		if (currentState.fillStyle !== this._contextFillStyle) {
+			this._context.fillStyle = currentState.fillStyle;
+			this._contextFillStyle = currentState.fillStyle;
+		}
+		if (currentState.globalAlpha !== this._contextGlobalAlpha) {
+			this._context.globalAlpha = currentState.globalAlpha;
+			this._contextGlobalAlpha = currentState.globalAlpha;
+		}
+		if (currentState.globalCompositeOperation !== this._contextGlobalCompositeOperation) {
+			this._context.globalCompositeOperation = currentState.globalCompositeOperation as GlobalCompositeOperation;
+			this._contextGlobalCompositeOperation = currentState.globalCompositeOperation;
+		}
+		if (this._modifiedTransform) {
+			this._modifiedTransform = false;
+			const transformer = currentState.transformer;
+
+			if (transformer.matrix[0] === 0 || transformer.matrix[3] === 0) {
+				// node-canvas 側の不具合? アフィン変換行列における拡大縮小の x, y の係数のいずれかが 0 の場合それ以降描画がされなくなる。
+				// そのためこれらの要素が 0 の際は context に対して変換行列を適用せず、描画をスキップする。
+				// @see https://github.com/Automattic/node-canvas/issues/702
+				return false;
+			}
+
+			// FIXME: canvas@2.11.2 時点で setTransform() の TypeScript の型定義が不足しているため暫定でコンパイルできるように修正
+			// @see https://github.com/Automattic/node-canvas/pull/2322
+			(this._context.setTransform as unknown as (a: number, b: number, c: number, d: number, e: number, f: number) => void)(
+				transformer.matrix[0],
+				transformer.matrix[1],
+				transformer.matrix[2],
+				transformer.matrix[3],
+				transformer.matrix[4],
+				transformer.matrix[5]
+			);
+		}
+
+		return true;
+	}
+
+	private pushState(state: RenderingState): void {
+		this._stateStack.push(state);
+	}
+
+	private popState(): void {
+		if (this._stateStack.length <= 1) {
+			return;
+		}
+		this._stateStack.pop();
+		this._modifiedTransform = true;
+	}
+
+	private currentState(): RenderingState {
+		return this._stateStack[this._stateStack.length - 1];
+	}
+}

--- a/src/runner/v3/platform/graphics/canvas/NodeCanvasRenderer.ts
+++ b/src/runner/v3/platform/graphics/canvas/NodeCanvasRenderer.ts
@@ -1,14 +1,15 @@
 /** @ts-ignore */
-import type { CanvasRenderingContext2D, ImageData } from "canvas";
+import type { ImageData } from "canvas";
 import type { akashicEngine as g } from "../../../engineFiles";
 import { CompositeOperationConverter } from "./CompositeOperationConverter";
+import type { NodeCanvasContext } from "./NodeCanvasContext";
 
 export class NodeCanvasRenderer implements g.Renderer {
-	private context: CanvasRenderingContext2D;
+	private context: NodeCanvasContext;
 	private width: number;
 	private height: number;
 
-	constructor(context: CanvasRenderingContext2D, width: number, height: number) {
+	constructor(context: NodeCanvasContext, width: number, height: number) {
 		this.context = context;
 		this.width = width;
 		this.height = height;
@@ -27,7 +28,7 @@ export class NodeCanvasRenderer implements g.Renderer {
 	}
 
 	end(): void {
-		// do notiong
+		// do nothing
 	}
 
 	drawImage(
@@ -39,7 +40,7 @@ export class NodeCanvasRenderer implements g.Renderer {
 		canvasOffsetX: number,
 		canvasOffsetY: number
 	): void {
-		this.context.drawImage(surface._drawable, offsetX, offsetY, width, height, canvasOffsetX, canvasOffsetY, width, height);
+		this.context.drawImage(surface, offsetX, offsetY, width, height, canvasOffsetX, canvasOffsetY, width, height);
 	}
 
 	translate(x: number, y: number): void {

--- a/src/runner/v3/platform/graphics/canvas/NodeCanvasSurface.ts
+++ b/src/runner/v3/platform/graphics/canvas/NodeCanvasSurface.ts
@@ -1,6 +1,7 @@
 /** @ts-ignore */
 import type { Canvas } from "canvas";
 import type { akashicEngine as g } from "../../../engineFiles";
+import { NodeCanvasContext } from "./NodeCanvasContext";
 import { NodeCanvasRenderer } from "./NodeCanvasRenderer";
 
 export class NodeCanvasSurface implements g.Surface {
@@ -13,7 +14,8 @@ export class NodeCanvasSurface implements g.Surface {
 		this.width = canvas.width;
 		this.height = canvas.height;
 		this._drawable = canvas;
-		this._renderer = new NodeCanvasRenderer(canvas.getContext("2d"), canvas.width, canvas.height);
+		const context = new NodeCanvasContext(canvas.getContext("2d"));
+		this._renderer = new NodeCanvasRenderer(context, canvas.width, canvas.height);
 	}
 
 	renderer(): NodeCanvasRenderer {

--- a/src/runner/v3/platform/graphics/canvas/RenderingState.ts
+++ b/src/runner/v3/platform/graphics/canvas/RenderingState.ts
@@ -1,0 +1,22 @@
+import { AffineTransformer } from "./AffineTransformer";
+
+export class RenderingState {
+	fillStyle: string;
+	globalAlpha: number;
+	globalCompositeOperation: string;
+	transformer: AffineTransformer;
+
+	constructor(crs?: RenderingState) {
+		if (crs) {
+			this.fillStyle = crs.fillStyle;
+			this.globalAlpha = crs.globalAlpha;
+			this.globalCompositeOperation = crs.globalCompositeOperation;
+			this.transformer = new AffineTransformer(crs.transformer);
+		} else {
+			this.fillStyle = "#000000";
+			this.globalAlpha = 1.0;
+			this.globalCompositeOperation = "source-over";
+			this.transformer = new AffineTransformer();
+		}
+	}
+}


### PR DESCRIPTION
# このPullRequestが解決する内容
node-canvas にて、`CanvasRenderingContext2D` の transform で指定するアフィン変換行列の拡大縮小の係数 x, y のいずれかが 0 のときに描画が完全に停止してしまうバグを修正します。

## 動作確認
次のミニマムコンテンツを実行したときにプライマリサーフェスの描画が停止しないことを確認

<details>
<summary>展開</summary>

```javascript
const tl = require("@akashic-extension/akashic-timeline");

module.exports = () => {
  const game = g.game;
  const scene = new g.Scene({
    game,
  });
  const timeline = new tl.Timeline(scene);
  scene.onLoad.addOnce(() => {
    const rect = new g.FilledRect({
      scene,
      cssColor: "red",
      width: 100,
      height: 100,
      x: game.width / 2,
      y: game.height / 2,
      anchorX: 0.5,
      anchorY: 0.5,
    });
    scene.append(rect);
    timeline
      .create(rect, { loop: true })
      .to({ scaleX: 0, scaleY: 0 }, 1000)
      .to({ scaleX: 1, scaleY: 1 }, 1000);
  });
  game.pushScene(scene);
};
```
</details>