### PR TITLE
fix: change the return value of Runner#step() to Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
-## unreleased changes
+## 2.14.0
 * `Runner` のリプレイモードをサポート
+* `Runner#step()` の戻り値の型を `Promise<void>` に変更
 
 ## 2.13.9
 * 内部モジュールの更新

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.13.9",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-driver",
-      "version": "2.13.9",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-driver",
-  "version": "2.13.9",
+  "version": "2.14.0",
   "description": "A library to execute contents using Akashic Engine headlessly",
   "main": "lib/index.js",
   "author": "DWANGO Co., Ltd.",

--- a/src/__tests__/renderer.spec.ts
+++ b/src/__tests__/renderer.spec.ts
@@ -68,7 +68,7 @@ describe("コンテンツのレンダリングテスト", () => {
 		const runnerContext = canvas.getContext("2d");
 
 		// compare and write the result
-		fs.readdirSync(expectedPath).forEach((filename, i) => {
+		for (const [i, filename] of fs.readdirSync(expectedPath).entries()) {
 			const expected = PNG.sync.read(fs.readFileSync(path.join(expectedPath, filename)));
 			const actual = runnerContext.getImageData(0, 0, width, height);
 			const diff = new PNG({ width, height });
@@ -82,8 +82,8 @@ describe("コンテンツのレンダリングテスト", () => {
 			fs.writeFileSync(path.join(diffPath, filenameTransformer(i)), diffPNG);
 			fs.writeFileSync(path.join(actualPath, filenameTransformer(i)), canvas.toBuffer());
 
-			runner.step();
-		});
+			await runner.step();
+		}
 
 		runner.stop();
 	}, 20000); // ファイル IO が絡む他、canvas の初期化で時間がかかる場合があるので長めに許容

--- a/src/__tests__/run.spec.ts
+++ b/src/__tests__/run.spec.ts
@@ -1,5 +1,4 @@
 import * as path from "node:path";
-import { setTimeout } from "timers/promises";
 import type { Tick } from "@akashic/playlog";
 import type { DumpedPlaylog, Runner, RunnerV1, RunnerV1Game, RunnerV2, RunnerV2Game, RunnerV3, RunnerV3Game } from "..";
 import { setSystemLogger } from "../Logger";
@@ -1437,21 +1436,16 @@ describe("リプレイの動作確認", () => {
 	async function doStepTest(runner: Runner, entrySceneName: string): Promise<void> {
 		const game = (await runner.start({ paused: true })) as RunnerV3Game;
 
-		// runner#step() を同期的に利用した場合、setImmediate() による非同期の処理が行われないバグがある。
-		// そのため明示的に setTimeout を挟んでいる。
 		while (game.scene()!.name !== entrySceneName) {
-			runner.step();
-			await setTimeout(0); // FIXME: この処理を消す
+			await runner.step();
 		}
 		while (game.vars.messages.length === 0) {
-			runner.step();
-			await setTimeout(0); // FIXME: この処理を消す
+			await runner.step();
 		}
 
 		let beforeMessagesLength = game.vars.messages.length;
 		while (game.vars.messages.length < ticks.length) {
-			runner.step();
-			await setTimeout(0);
+			await runner.step();
 			// 必ず 1 フレームずつ進むことを確認
 			expect(game.vars.messages.length).toBe(beforeMessagesLength + 1);
 			beforeMessagesLength = game.vars.messages.length;
@@ -1461,15 +1455,11 @@ describe("リプレイの動作確認", () => {
 	async function doAdvanceTest(runner: Runner, entrySceneName: string): Promise<void> {
 		const game = (await runner.start({ paused: true })) as RunnerV3Game;
 
-		// runner#step() を同期的に利用した場合、setImmediate() による非同期の処理が行われないバグがある。
-		// そのため明示的に setTimeout を挟んでいる。
 		while (game.scene()!.name !== entrySceneName) {
-			runner.step();
-			await setTimeout(0); // FIXME: この処理を消す
+			await runner.step();
 		}
 		while (game.vars.messages.length === 0) {
-			runner.step();
-			await setTimeout(0); // FIXME: この処理を消す
+			await runner.step();
 		}
 
 		let beforeMessagesLength = game.vars.messages.length;

--- a/src/__tests__/runner.spec.ts
+++ b/src/__tests__/runner.spec.ts
@@ -277,11 +277,11 @@ describe("Runner の動作確認 (v3)", () => {
 		});
 
 		// step() を呼び出すたびに g.Scene#onUpdate が発火することを確認
-		runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update"]);
-		runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update"]);
-		runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update", "scene_update"]);
 
 		runner.stop();
@@ -362,9 +362,9 @@ describe("Runner の engine-files 上書き動作確認", () => {
 			if (l === "scene_update") logs.push(l);
 		});
 
-		runner.step();
-		runner.step();
-		runner.step();
+		await runner.step();
+		await runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update", "scene_update"]);
 		expect((globalThis as any)[`__test_${randStr}__`]).toBe(true);
 
@@ -392,9 +392,9 @@ describe("Runner の engine-files 上書き動作確認", () => {
 			if (l === "scene_update") logs.push(l);
 		});
 
-		runner.step();
-		runner.step();
-		runner.step();
+		await runner.step();
+		await runner.step();
+		await runner.step();
 		expect(logs).toEqual(["scene_update", "scene_update", "scene_update"]);
 		expect((globalThis as any)[`__test_${randStr}__`]).toBe(true);
 
@@ -425,7 +425,7 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.errorTrigger.add((e) => {
 			err = e;
 		});
-		runner.step();
+		await runner.step();
 		// trigger 経由でエラーが通知されることを確認
 		expect(err).not.toBeUndefined();
 		runner.stop();
@@ -453,7 +453,7 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.errorTrigger.add((e) => {
 			err = e;
 		});
-		runner.step();
+		await runner.step();
 		// trigger 経由でエラーが通知されることを確認
 		expect(err).not.toBeUndefined();
 		runner.stop();
@@ -481,7 +481,7 @@ describe("Runner の動作確認 (異常系)", () => {
 		runner.errorTrigger.add((e) => {
 			err = e;
 		});
-		runner.step();
+		await runner.step();
 		// trigger 経由でエラーが通知されることを確認
 		expect(err).not.toBeUndefined();
 		runner.stop();

--- a/src/runner/Platform.ts
+++ b/src/runner/Platform.ts
@@ -34,6 +34,8 @@ export abstract class Platform {
 		this.loadFileHandler = param.loadFileHandler;
 	}
 
+	abstract advanceLoopers(ms: number): void;
+
 	sendToExternal(_playId: string, data: any): void {
 		this.sendToExternalHandler(data);
 	}

--- a/src/runner/Runner.ts
+++ b/src/runner/Runner.ts
@@ -153,7 +153,7 @@ export abstract class Runner {
 	/**
 	 * Runner を一フレーム進行する。
 	 */
-	abstract step(): void;
+	abstract step(): Promise<void>;
 	/**
 	 * Runner に対して任意のポイントイベントを発火させる。
 	 * @param event 発火させるポイントイベント
@@ -172,9 +172,9 @@ export abstract class Runner {
 	 */
 	async advanceUntil(condition: RunnerAdvanceConditionFunc, timeout: number = 5000): Promise<void> {
 		return new Promise((resolve, reject) => {
-			const limit = Date.now() + timeout;
+			const limit = performance.now() + timeout;
 			const handler = (): void => {
-				if (limit < Date.now()) {
+				if (limit < performance.now()) {
 					return void reject(new Error("Runner#advanceUntil(): processing timeout"));
 				}
 				try {
@@ -189,6 +189,9 @@ export abstract class Runner {
 		});
 	}
 
+	/**
+	 * 次フレームを飛ばさない程度に時間を進める。
+	 */
 	protected abstract _stepMinimal(): void;
 
 	protected onError(error: Error): void {

--- a/src/runner/Runner.ts
+++ b/src/runner/Runner.ts
@@ -1,5 +1,6 @@
 import type { AMFlow } from "@akashic/amflow";
 import { Trigger } from "@akashic/trigger";
+import { TimeKeeper } from "../TimeKeeper";
 import type { Platform } from "./Platform";
 import type {
 	RunnerAdvanceConditionFunc,
@@ -48,6 +49,8 @@ export abstract class Runner {
 	abstract readonly g: any;
 
 	abstract platform: Platform | null;
+
+	abstract fps: number | null;
 
 	errorTrigger: Trigger<Error> = new Trigger();
 
@@ -123,6 +126,10 @@ export abstract class Runner {
 		return this.params.externalValue;
 	}
 
+	protected timekeeper: TimeKeeper = new TimeKeeper();
+	protected timekeeperTimerId: NodeJS.Timer | null = null;
+	protected timekeeperPrevTime: number = 0;
+
 	constructor(params: RunnerParameters) {
 		this.params = params;
 	}
@@ -193,6 +200,50 @@ export abstract class Runner {
 	 * 次フレームを飛ばさない程度に時間を進める。
 	 */
 	protected abstract _stepMinimal(): void;
+
+	protected advancePlatform(ms: number): void {
+		// 以下のメソッドプロパティが存在することは呼び出し側で保証する
+		const fps = this.fps!;
+		const platform = this.platform!;
+		const timekeeper = this.timekeeper;
+
+		const frame = 1000 / fps;
+		const frameWithGrace = frame * 1.2; // 1 フレームよりも少し大きめの値
+		const steps = Math.floor(ms / frame);
+		let progress = 0;
+		for (let i = 0; i < steps; i++) {
+			const now = timekeeper.now();
+			// NOTE: 浮動小数による誤差を考慮し、 1 フレームよりも少し大きめに目標時刻を進め、その後 Looper を確実に進めた後に再度目標時刻を正常値に戻す。
+			timekeeper.advance(frameWithGrace);
+			// NOTE: game-driver の内部実装により Looper 経由で一度に進める時間に制限がある。
+			// そのため一度に進める時間を fps に応じて分割する。
+			platform.advanceLoopers(frame);
+			timekeeper.set(now + frame);
+			progress += frame;
+		}
+		timekeeper.advance(ms - progress);
+		platform.advanceLoopers(ms - progress);
+	}
+
+	protected startTimekeeper(): void {
+		this.stopTimekeeper();
+		const duration = 1000 / this.fps! / 2; // this.fps != null の条件でのみしか呼ばれないため non-null assertion を利用
+		this.timekeeperPrevTime = performance.now();
+		this.timekeeperTimerId = setInterval(() => {
+			const now = performance.now();
+			const delta = now - this.timekeeperPrevTime;
+			this.timekeeper.advance(delta);
+			this.timekeeperPrevTime = now;
+		}, duration);
+	}
+
+	protected stopTimekeeper(): void {
+		if (this.timekeeperTimerId == null) {
+			return;
+		}
+		clearInterval(this.timekeeperTimerId);
+		this.timekeeperTimerId = null;
+	}
 
 	protected onError(error: Error): void {
 		this.stop();

--- a/src/runner/v1/RunnerV1.ts
+++ b/src/runner/v1/RunnerV1.ts
@@ -1,6 +1,5 @@
 import { setImmediate } from "node:timers/promises";
 import { akashicEngine as g, gameDriver as gdr, pdi } from "engine-files-v1";
-import { TimeKeeper } from "../../TimeKeeper";
 import type { RunnerStartParameters } from "../Runner";
 import { Runner } from "../Runner";
 import type { RunnerPointEvent } from "../types";
@@ -16,10 +15,6 @@ export class RunnerV1 extends Runner {
 
 	private driver: gdr.GameDriver | null = null;
 	private running: boolean = false;
-
-	private timekeeper: TimeKeeper = new TimeKeeper();
-	private timekeeperTimerId: NodeJS.Timer | null = null;
-	private timekeeperPrevTime: number = 0;
 
 	async start(params?: RunnerStartParameters): Promise<RunnerV1Game | null> {
 		let game: RunnerV1Game | null = null;
@@ -117,22 +112,7 @@ export class RunnerV1 extends Runner {
 			}
 		});
 
-		const frame = 1000 / this.fps;
-		const frameWithGrace = frame * 1.2; // Looper を確実に進めるため 1 フレームよりも少し大きめの値を与える
-		const steps = Math.floor(ms / frame);
-		let progress = 0;
-		for (let i = 0; i < steps; i++) {
-			const now = this.timekeeper.now();
-			// NOTE: 浮動小数による誤差を考慮し、 1 フレームよりも少し大きめに目標時刻を進め、その後 Looper を確実に進めた後に再度目標時刻を正常値に戻す。
-			this.timekeeper.advance(frameWithGrace);
-			// NOTE: game-driver の内部実装により Looper 経由で一度に進める時間に制限がある。
-			// そのため一度に進める時間を fps に応じて分割する。
-			this.platform.advanceLoopers(frame);
-			this.timekeeper.set(now + frame);
-			progress += frame;
-		}
-		this.timekeeper.advance(ms - progress);
-		this.platform.advanceLoopers(ms - progress);
+		this.advancePlatform(ms);
 
 		await this.changeGameDriverState({
 			loopConfiguration: {
@@ -178,26 +158,6 @@ export class RunnerV1 extends Runner {
 
 	getPrimarySurface(): never {
 		throw new Error("RunnerV1#getPrimarySurface(): Not supported");
-	}
-
-	private startTimekeeper(): void {
-		this.stopTimekeeper();
-		const duration = 1000 / this.fps! / 2; // this.fps != null の条件でのみしか呼ばれないため non-null assertion を利用
-		this.timekeeperPrevTime = performance.now();
-		this.timekeeperTimerId = setInterval(() => {
-			const now = performance.now();
-			const delta = now - this.timekeeperPrevTime;
-			this.timekeeper.advance(delta);
-			this.timekeeperPrevTime = now;
-		}, duration);
-	}
-
-	private stopTimekeeper(): void {
-		if (this.timekeeperTimerId == null) {
-			return;
-		}
-		clearInterval(this.timekeeperTimerId);
-		this.timekeeperTimerId = null;
 	}
 
 	private initGameDriver(): Promise<RunnerV1Game> {

--- a/src/runner/v1/RunnerV1.ts
+++ b/src/runner/v1/RunnerV1.ts
@@ -1,3 +1,4 @@
+import { setImmediate } from "node:timers/promises";
 import { akashicEngine as g, gameDriver as gdr, pdi } from "engine-files-v1";
 import { TimeKeeper } from "../../TimeKeeper";
 import type { RunnerStartParameters } from "../Runner";
@@ -68,7 +69,7 @@ export class RunnerV1 extends Runner {
 		this.running = true;
 	}
 
-	step(): void {
+	async step(): Promise<void> {
 		if (this.fps == null || this.platform == null) {
 			this.errorTrigger.fire(new Error("Cannot call Runner#step() before initialized"));
 			return;
@@ -80,15 +81,16 @@ export class RunnerV1 extends Runner {
 
 		this.timekeeper.advance(1000 / this.fps);
 		this.platform.advanceLoopers(Math.ceil(1000 / this.fps));
+		await setImmediate();
 	}
 
 	protected _stepMinimal(): void {
 		if (this.fps == null || this.platform == null) {
-			this.errorTrigger.fire(new Error("RunnerV1#_stepHalf(): Cannot call Runner#step() before initialized"));
+			this.errorTrigger.fire(new Error("RunnerV1#_stepMinimal(): Cannot call Runner#step() before initialized"));
 			return;
 		}
 		if (this.running) {
-			this.errorTrigger.fire(new Error("RunnerV1#_stepHalf(): Cannot call Runner#step() in running"));
+			this.errorTrigger.fire(new Error("RunnerV1#_stepMinimal(): Cannot call Runner#step() in running"));
 			return;
 		}
 		// NOTE: 現状 PDI の API 仕様により this.step() では厳密なフレーム更新ができない。そこで、一フレームの 1/2 の時間で進行することでフレームが飛んでしまうことを防止する。

--- a/src/runner/v1/platform/assets/NullAudioAsset.ts
+++ b/src/runner/v1/platform/assets/NullAudioAsset.ts
@@ -2,8 +2,8 @@ import { akashicEngine as g } from "engine-files-v1";
 
 export class NullAudioAsset extends g.AudioAsset {
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 }

--- a/src/runner/v1/platform/assets/NullImageAsset.ts
+++ b/src/runner/v1/platform/assets/NullImageAsset.ts
@@ -5,9 +5,9 @@ export class NullImageAsset extends g.ImageAsset {
 	_surface: g.Surface | null = null;
 
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v1/platform/assets/NullVideoAsset.ts
+++ b/src/runner/v1/platform/assets/NullVideoAsset.ts
@@ -11,9 +11,9 @@ export class NullVideoAsset extends g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v2/RunnerV2.ts
+++ b/src/runner/v2/RunnerV2.ts
@@ -1,3 +1,4 @@
+import { setImmediate } from "node:timers/promises";
 import { akashicEngine as g, gameDriver as gdr, pdi } from "engine-files-v2";
 import { TimeKeeper } from "../../TimeKeeper";
 import type { RunnerStartParameters } from "../Runner";
@@ -68,7 +69,7 @@ export class RunnerV2 extends Runner {
 		this.running = true;
 	}
 
-	step(): void {
+	async step(): Promise<void> {
 		if (this.fps == null || this.platform == null) {
 			this.errorTrigger.fire(new Error("Cannot call Runner#step() before initialized"));
 			return;
@@ -80,6 +81,7 @@ export class RunnerV2 extends Runner {
 
 		this.timekeeper.advance(1000 / this.fps);
 		this.platform.advanceLoopers(Math.ceil(1000 / this.fps));
+		await setImmediate();
 	}
 
 	async advance(ms: number): Promise<void> {
@@ -167,11 +169,11 @@ export class RunnerV2 extends Runner {
 
 	protected _stepMinimal(): void {
 		if (this.fps == null || this.platform == null) {
-			this.errorTrigger.fire(new Error("RunnerV2#_stepHalf(): Cannot call Runner#step() before initialized"));
+			this.errorTrigger.fire(new Error("RunnerV2#_stepMinimal(): Cannot call Runner#step() before initialized"));
 			return;
 		}
 		if (this.running) {
-			this.errorTrigger.fire(new Error("RunnerV2#_stepHalf(): Cannot call Runner#step() in running"));
+			this.errorTrigger.fire(new Error("RunnerV2#_stepMinimal(): Cannot call Runner#step() in running"));
 			return;
 		}
 		// NOTE: 現状 PDI の API 仕様により this.step() では厳密なフレーム更新ができない。そこで、一フレームの 1/2 の時間で進行することでフレームが飛んでしまうことを防止する。

--- a/src/runner/v2/RunnerV2.ts
+++ b/src/runner/v2/RunnerV2.ts
@@ -1,6 +1,5 @@
 import { setImmediate } from "node:timers/promises";
 import { akashicEngine as g, gameDriver as gdr, pdi } from "engine-files-v2";
-import { TimeKeeper } from "../../TimeKeeper";
 import type { RunnerStartParameters } from "../Runner";
 import { Runner } from "../Runner";
 import type { RunnerPointEvent } from "../types";
@@ -16,10 +15,6 @@ export class RunnerV2 extends Runner {
 
 	private driver: gdr.GameDriver | null = null;
 	private running: boolean = false;
-
-	private timekeeper: TimeKeeper = new TimeKeeper();
-	private timekeeperTimerId: NodeJS.Timer | null = null;
-	private timekeeperPrevTime: number = 0;
 
 	async start(params?: RunnerStartParameters): Promise<RunnerV2Game | null> {
 		let game: RunnerV2Game | null = null;
@@ -104,22 +99,7 @@ export class RunnerV2 extends Runner {
 			}
 		});
 
-		const frame = 1000 / this.fps;
-		const frameWithGrace = frame * 1.2; // Looper を確実に進めるため 1 フレームよりも少し大きめの値を与える
-		const steps = Math.floor(ms / frame);
-		let progress = 0;
-		for (let i = 0; i < steps; i++) {
-			const now = this.timekeeper.now();
-			// NOTE: 浮動小数による誤差を考慮し、 1 フレームよりも少し大きめに目標時刻を進め、その後 Looper を確実に進めた後に再度目標時刻を正常値に戻す。
-			this.timekeeper.advance(frameWithGrace);
-			// NOTE: game-driver の内部実装により Looper 経由で一度に進める時間に制限がある。
-			// そのため一度に進める時間を fps に応じて分割する。
-			this.platform.advanceLoopers(frame);
-			this.timekeeper.set(now + frame);
-			progress += frame;
-		}
-		this.timekeeper.advance(ms - progress);
-		this.platform.advanceLoopers(ms - progress);
+		this.advancePlatform(ms);
 
 		await this.changeGameDriverState({
 			loopConfiguration: {
@@ -178,26 +158,6 @@ export class RunnerV2 extends Runner {
 		}
 		// NOTE: 現状 PDI の API 仕様により this.step() では厳密なフレーム更新ができない。そこで、一フレームの 1/2 の時間で進行することでフレームが飛んでしまうことを防止する。
 		this.platform.advanceLoopers(1000 / this.fps / 2);
-	}
-
-	private startTimekeeper(): void {
-		this.stopTimekeeper();
-		const duration = 1000 / this.fps! / 2; // this.fps != null の条件でのみしか呼ばれないため non-null assertion を利用
-		this.timekeeperPrevTime = performance.now();
-		this.timekeeperTimerId = setInterval(() => {
-			const now = performance.now();
-			const delta = now - this.timekeeperPrevTime;
-			this.timekeeper.advance(delta);
-			this.timekeeperPrevTime = now;
-		}, duration);
-	}
-
-	private stopTimekeeper(): void {
-		if (this.timekeeperTimerId == null) {
-			return;
-		}
-		clearInterval(this.timekeeperTimerId);
-		this.timekeeperTimerId = null;
 	}
 
 	private initGameDriver(): Promise<RunnerV2Game> {

--- a/src/runner/v2/platform/assets/NullAudioAsset.ts
+++ b/src/runner/v2/platform/assets/NullAudioAsset.ts
@@ -2,8 +2,8 @@ import { akashicEngine as g } from "engine-files-v2";
 
 export class NullAudioAsset extends g.AudioAsset {
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 }

--- a/src/runner/v2/platform/assets/NullImageAsset.ts
+++ b/src/runner/v2/platform/assets/NullImageAsset.ts
@@ -5,9 +5,9 @@ export class NullImageAsset extends g.ImageAsset {
 	_surface: g.Surface | null = null;
 
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v2/platform/assets/NullVideoAsset.ts
+++ b/src/runner/v2/platform/assets/NullVideoAsset.ts
@@ -11,9 +11,9 @@ export class NullVideoAsset extends g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v3/platform/audios/NullAudioAsset.ts
+++ b/src/runner/v3/platform/audios/NullAudioAsset.ts
@@ -29,9 +29,9 @@ export class NullAudioAsset extends Asset implements g.AudioAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 
 	play(): g.AudioPlayer {

--- a/src/runner/v3/platform/graphics/null/NullImageAsset.ts
+++ b/src/runner/v3/platform/graphics/null/NullImageAsset.ts
@@ -17,9 +17,9 @@ export class NullImageAsset extends Asset implements g.ImageAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 
 	asSurface(): g.Surface {

--- a/src/runner/v3/platform/videos/NullVideoAsset.ts
+++ b/src/runner/v3/platform/videos/NullVideoAsset.ts
@@ -29,9 +29,9 @@ export class NullVideoAsset extends Asset implements g.VideoAsset {
 	}
 
 	_load(loader: g.AssetLoadHandler): void {
-		setTimeout(() => {
+		setImmediate(() => {
 			loader._onAssetLoad(this);
-		}, 0);
+		});
 	}
 
 	asSurface(): g.Surface {


### PR DESCRIPTION
# このPullRequestが解決する内容
* `Runner#step()` の戻り値を `Promise` に変更します。
  * アセット読み込み・AMFlow のコールバックなどの `setImmediate()` を `Runner#step()` の完了タイミングで確実に処理するため、`Runner#step()` の完了を `setImmediate()` で遅延させるように修正します。
  * 現バージョンにおいては realtime のみサポートしていたためユーザ影響は少ないと考え、マイナーバージョンの更新としています。
* #650 で追加した処理をリファクタリングします。